### PR TITLE
feat: Auto Sync

### DIFF
--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           sed -i 's/jisccti/${{ vars.DOCKERHUB_ORGANISATION }}/g' docker-compose.yml
           sed -i 's/latest/latest-dev/g' docker-compose.yml
+          sed -i 's/{MISP_VERSION}/{MISP_VERSION}-dev/g' misp-workers/Dockerfile
           cp example.env .env
           mkdir -p persistent/$COMPOSE_PROJECT_NAME/gpg persistent/$COMPOSE_PROJECT_NAME/tls
           cat <<EOF > persistent/$COMPOSE_PROJECT_NAME/gpg/import.asc

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -13,7 +13,7 @@ on:
 env:
   COMPOSE_PROJECT_NAME: misp_dev
 jobs:
-  run:
+  run-dev:
     name: Build, Test, and Release
     runs-on: ubuntu-latest
     steps:
@@ -35,6 +35,7 @@ jobs:
         run: |
           sed -i 's/jisccti/${{ vars.DOCKERHUB_ORGANISATION }}/g' docker-compose.yml
           sed -i 's/latest/latest-dev/g' docker-compose.yml
+          sed -i 's/jisccti/${{ vars.DOCKERHUB_ORGANISATION }}/g' misp-workers/Dockerfile
           sed -i 's/{MISP_VERSION}/{MISP_VERSION}-dev/g' misp-workers/Dockerfile
           cp example.env .env
           mkdir -p persistent/$COMPOSE_PROJECT_NAME/gpg persistent/$COMPOSE_PROJECT_NAME/tls
@@ -59,13 +60,16 @@ jobs:
           latest: true
           prerelease: false
           repo: MISP/MISP
+      - id: modules_version
+        name: Get current MISP modules version number
+        run: echo "MODULES_VERSION=$(python3 ./misp-modules/latest.py)" >> $GITHUB_ENV
 
       # Build / Pull Images
       - id: build_modules
         name: Build misp-modules
         run: |
           cd misp-modules
-          docker build -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:latest-dev -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ steps.version.outputs.tag_name }}-dev --build-arg MISP_VERSION="${{ steps.version.outputs.tag_name }}" .
+          docker build -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:latest-dev -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ env.MODULES_VERSION }}-dev --build-arg MISP_VERSION="${{ env.MODULES_VERSION }}" .
           cd ..
       - id: build_web
         name: Build misp-web
@@ -79,7 +83,7 @@ jobs:
           cd misp-workers
           docker build -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-workers:latest-dev -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-workers:${{ steps.version.outputs.tag_name }}-dev --build-arg MISP_VERSION="${{ steps.version.outputs.tag_name }}" .
           cd ..
-      
+
       # Test
       - id: start_test_env
         name: Deploy Test Instance
@@ -107,7 +111,7 @@ jobs:
         name: Push misp-modules
         if: steps.build_modules.outcome == 'success'
         run: |
-          docker image push ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ steps.version.outputs.tag_name }}-dev
+          docker image push ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ env.MODULES_VERSION }}-dev
           docker image push ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:latest-dev
       - id: push-web
         name: Push misp-web

--- a/.github/workflows/production-images.yml
+++ b/.github/workflows/production-images.yml
@@ -35,6 +35,7 @@ jobs:
         name: Configure Environment
         run: |
           sed -i 's/jisccti/${{ vars.DOCKERHUB_ORGANISATION }}/g' docker-compose.yml
+          sed -i 's/jisccti/${{ vars.DOCKERHUB_ORGANISATION }}/g' misp-workers/Dockerfile
           cp example.env .env
           mkdir -p persistent/$COMPOSE_PROJECT_NAME/gpg persistent/$COMPOSE_PROJECT_NAME/tls
           cat <<EOF > persistent/$COMPOSE_PROJECT_NAME/gpg/import.asc
@@ -58,6 +59,9 @@ jobs:
           latest: true
           prerelease: false
           repo: MISP/MISP
+      - id: modules_version
+        name: Get current MISP modules version number
+        run: echo "MODULES_VERSION=$(python3 ./misp-modules/latest.py)" >> $GITHUB_ENV
       - id: modules_image_exists
         continue-on-error: true
         name: Check If misp-modules Image Exists
@@ -66,7 +70,7 @@ jobs:
           organization: ${{ vars.DOCKERHUB_ORGANISATION }}
           registry: registry.hub.docker.com
           repository: misp-modules
-          tag: ${{ steps.version.outputs.tag_name }}
+          tag: ${{ env.MODULES_VERSION }}
       - id: web_image_exists
         continue-on-error: true
         name: Check If misp-web Image Exists
@@ -92,7 +96,7 @@ jobs:
         name: Build misp-modules
         run: |
           cd misp-modules
-          docker build -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:latest -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ steps.version.outputs.tag_name }} --build-arg MISP_VERSION="${{ steps.version.outputs.tag_name }}" .
+          docker build -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:latest -t ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ env.MODULES_VERSION }} --build-arg MISP_VERSION="${{ env.MODULES_VERSION }}" .
           cd ..
       - id: pull_modules
         if: ${{ steps.modules_image_exists.outcome != 'failure' && github.event_name != 'push' && github.event_name != 'workflow_dispatch' }}
@@ -148,7 +152,7 @@ jobs:
         name: Push misp-modules
         if: steps.build_modules.outcome == 'success'
         run: |
-          docker image push ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ steps.version.outputs.tag_name }}
+          docker image push ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ env.MODULES_VERSION }}
           docker image push ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:latest
       - id: push-web
         name: Push misp-web

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Where you need to add taxonomies and similar custom content after initial setup,
 sub-directories of `./persistent/{instanceName}/data/files/` and loaded into the database by running
 `/opt/scripts/update-objects.sh` within the container.
 
-### 10 - Maintaining MISP Objects
+### 10 - Automated Maintenance
 
 Routine tasks have been automated in the misp-workers container which will run the following:
 
@@ -259,3 +259,31 @@ In order for feed and server synchronisation to run:
 5. In the "Add auth key" dialog that appears, for "Comment", enter "Docker Automation" and click Submit.
 6. Edit `/var/www/MISPData/misp_maintenance_jobs.ini` on `misp-workers` setting `authkey` to the 40 character key shown
    in the "Auth key created" dialog.
+
+#### Custom Automations
+
+The maintenance scheduling system is extensible, meaning you can add your own automations to run periodically.
+
+To add a custom automation:
+
+1. Create your automation, if you need to talk to the MISP API, it is recommended you read `authKey`, `baseUrl`, and
+  `verifyTls` from the `DEFAULT` section of `/var/www/MISPData/misp_maintenance_jobs.ini` for consistency.
+2. Place the automation into its own folder within `/var/www/MISPData/custom_scripts` on the `misp-workers` container.
+    * For Python automations, use `/usr/local/bin/python3 -m venv venv` to create a virtual environment.
+3. Add a section to `/var/www/MISPData/misp_maintenance_jobs.ini` to schedule your task (see the example below).
+    * The section name (`unique_job_name` below) must be unique.
+    * `command` should use absolute paths to executables and scripts.
+    * `enabled` allows a job to be temporarily disabled without removing it.
+    * `interval` sets how often the automation should be triggered, in minutes.
+    * `lastRun` is set by the scheduling system and should be set to 0 on creation.
+    * Setting `needsAuthKey` to `True` will prevent the automation from running until a valid Auth Key has been set as
+      above.
+
+```ini
+[unique_job_name]
+command = /var/www/MISPData/custom_scripts/unique_job_name/venv/python3 /var/www/MISPData/custom_scripts/unique_job_name/unique_job_name.py
+enabled = True
+interval = 60
+lastRun = 0
+needsAuthKey = False
+```

--- a/README.md
+++ b/README.md
@@ -250,16 +250,6 @@ Routine tasks have been automated in the misp-workers container which will run t
 | Run feed and server synchronisation tasks | Hourly |
 | Update Decay Models, Galaxies, Notice Lists, Objects, Taxonomies, Warning Lists, and Workflow Blueprints | Daily |
 
-In order for feed and server synchronisation to run:
-
-1. Access MISP via https://{FQDN}:{HTTPS_PORT}.
-2. Log in as the primary user (updated above).
-3. Go to Global Actions / My Profile.
-4. Click Auth Keys then Add Authentication Key.
-5. In the "Add auth key" dialog that appears, for "Comment", enter "Docker Automation" and click Submit.
-6. Edit `/var/www/MISPData/misp_maintenance_jobs.ini` on `misp-workers` setting `authkey` to the 40 character key shown
-   in the "Auth key created" dialog.
-
 #### Custom Automations
 
 The maintenance scheduling system is extensible, meaning you can add your own automations to run periodically.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ SPDX-License-Identifier: GPL-3.0-only
 
 [![Production Images](https://github.com/jisccti/misp-docker/actions/workflows/production-images.yml/badge.svg)](https://github.com/jisccti/misp-docker/actions/workflows/production-images.yml)
 [![MISP release](https://img.shields.io/github/v/release/MISP/MISP?logo=github&label=MISP%20(source))](https://github.com/MISP/MISP)
-[![misp-modules](https://img.shields.io/docker/v/jisccti/misp-modules?logo=docker&label=misp-modules)![misp-modules size](https://img.shields.io/docker/image-size/jisccti/misp-modules?label=%20)](https://hub.docker.com/r/jisccti/misp-modules)
-[![misp-web](https://img.shields.io/docker/v/jisccti/misp-web?logo=docker&label=misp-web)![misp-web size](https://img.shields.io/docker/image-size/jisccti/misp-web?label=%20)](https://hub.docker.com/r/jisccti/misp-web)
-[![misp-workers](https://img.shields.io/docker/v/jisccti/misp-workers?logo=docker&label=misp-workers)![misp-workers size](https://img.shields.io/docker/image-size/jisccti/misp-workers?label=%20)](https://hub.docker.com/r/jisccti/misp-workers)
+[![misp-modules](https://img.shields.io/docker/v/jisccti/misp-modules?sort=semver&logo=docker&label=misp-modules)![misp-modules size](https://img.shields.io/docker/image-size/jisccti/misp-modules/latest?label=%20)](https://hub.docker.com/r/jisccti/misp-modules)
+[![misp-web](https://img.shields.io/docker/v/jisccti/misp-web?sort=semver&logo=docker&label=misp-web)![misp-web size](https://img.shields.io/docker/image-size/jisccti/misp-web/latest?label=%20)](https://hub.docker.com/r/jisccti/misp-web)
+[![misp-workers](https://img.shields.io/docker/v/jisccti/misp-workers?sort=semver&logo=docker&label=misp-workers)![misp-workers size](https://img.shields.io/docker/image-size/jisccti/misp-workers/latest?label=%20)](https://hub.docker.com/r/jisccti/misp-workers)
 
 Project to build a set of three docker images containing the components of [MISP](https://github.com/MISP/MISP) with
 self-configuration into a usable state from first start.

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -91,6 +91,8 @@ services:
     image: jisccti/misp-workers:latest
     restart: unless-stopped
     environment:
+      - FQDN=${FQDN:-misp.local}
+      - HTTPS_PORT=${HTTPS_PORT:-443}
       - REDIS_HOST=${REDIS_HOST:-misp_redis}
       - WORKERS_PASSWORD=${WORKERS_PASSWORD:-misp}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,8 @@ services:
     image: jisccti/misp-workers:latest
     restart: unless-stopped
     environment:
+      - FQDN=${FQDN:-misp.local}
+      - HTTPS_PORT=${HTTPS_PORT:-443}
       - REDIS_HOST=${REDIS_HOST:-misp_redis}
       - WORKERS_PASSWORD=${WORKERS_PASSWORD:-misp}
     depends_on:

--- a/misp-modules/Dockerfile
+++ b/misp-modules/Dockerfile
@@ -9,14 +9,17 @@ ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 # Install build dependencies
 RUN mkdir -p /usr/local/src/misp_modules /misp_modules &&\
     apt-get update &&\
-    apt-get install -y git libpq5 libjpeg-dev tesseract-ocr libpoppler-cpp-dev imagemagick virtualenv libopencv-dev\
+    apt-get install -y g++ git libpq5 libjpeg-dev tesseract-ocr libpoppler-cpp-dev imagemagick libopencv-dev\
     zbar-tools libzbar0 libzbar-dev libfuzzy-dev
 
 # Install MISP Modules
 RUN git clone --branch ${MISP_VERSION} --single-branch https://github.com/MISP/misp-modules.git\
-    /usr/local/src/misp_modules &&\
-    virtualenv -p python3 /misp_modules &&\
-    cd /usr/local/src/misp_modules &&\
+    /usr/local/src/misp_modules
+WORKDIR /usr/local/src/misp_modules
+RUN python3 -m venv /misp_modules &&\
+    /misp_modules/bin/pip3 install --upgrade pip --no-cache-dir &&\
+    /misp_modules/bin/pip3 install greynoise pyeti redis --no-cache-dir &&\
+    /misp_modules/bin/pip3 install git+https://github.com/abenassi/Google-Search-API &&\
     /misp_modules/bin/pip3 install -I -r REQUIREMENTS --no-cache-dir &&\
     /misp_modules/bin/pip3 install . --no-cache-dir
 
@@ -30,7 +33,7 @@ LABEL Name="misp-modules" Version=${MISP_VERSION}\
 EXPOSE 6666
 
 RUN apt-get update &&\
-    apt-get install -y curl libgl1 libglib2.0-0 libpoppler-cpp0v5 libzbar0 virtualenv &&\
+    apt-get install -y curl libgl1 libglib2.0-0 libpoppler-cpp0v5 libzbar0 &&\
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /misp_modules/ /misp_modules/

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -92,7 +92,7 @@ RUN git config --global advice.detachedHead false &&\
     ./venv/bin/pip -q install plyara yara &&\
     cd PyMISP &&\
     git submodule foreach "git pull -q origin main || git pull -q origin master || exit 0" &&\
-    /var/www/MISP/venv/bin/pip -q install /var/www/MISP/PyMISP/.[fileobjects,neo,openioc,virustotal,pdfexport] &&\
+    /var/www/MISP/venv/bin/pip -q install /var/www/MISP/PyMISP/.[fileobjects,openioc,virustotal,pdfexport] &&\
     cd /var/www/ &&\
     chown -R www-data: MISP &&\
     chmod -R 750 MISP &&\

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -28,6 +28,19 @@ RUN apt -qy update &&\
     make install &&\
     docker-php-ext-enable apcu brotli gnupg rdkafka redis simdjson ssdeep
 
+# Build Python 3.10
+FROM debian:bullseye AS python_build
+RUN apt -yq update
+RUN apt -yq install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev
+WORKDIR /opt/
+RUN wget https://www.python.org/ftp/python/3.10.12/Python-3.10.12.tgz
+RUN tar xfz Python-3.10.12.tgz
+WORKDIR /opt/Python-3.10.12
+RUN ./configure --prefix=/usr/local --enable-optimizations
+RUN make
+RUN make install
+RUN python3 -m pip install --upgrade pip setuptools
+
 # Build MISP
 FROM php:7.4-apache AS misp_build
 ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
@@ -35,13 +48,13 @@ ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 COPY --from=php_build --chown=root:root /usr/local/lib/php/extensions/no-debug-non-zts-20190902/ \
     /usr/local/lib/php/extensions/no-debug-non-zts-20190902/
 COPY --from=php_build --chown=root:root /usr/local/etc/php/ /usr/local/etc/php/
+COPY --from=python_build /usr/local /usr/local
 
 # Install build dependencies
 RUN apt -qy update &&\
     apt -qy install --no-install-recommends cmake gcc git libcaca-dev libfuzzy-dev libgpgme11 libjpeg-dev liblua5.3-dev\
     libopencv-dev libpoppler-cpp-dev librdkafka-dev libxml2-dev libxslt1-dev libyara-dev libzbar-dev libzip4 make\
     openssl\
-    python3-dev python3-pip python3-redis python3-setuptools python3-virtualenv python3-yara python3-zmq\
     ruby sqlite3 ssdeep tesseract-ocr unzip zip zlib1g-dev
 
 # Download MISP
@@ -67,7 +80,8 @@ RUN git config --global advice.detachedHead false &&\
     php-http/message-factory &&\
     cd .. &&\
     cp -fa INSTALL/setup/config.php app/Plugin/CakeResque/Config/config.php &&\
-    virtualenv -p python3 ./venv &&\
+    python3 -m venv venv &&\
+    ./venv/bin/pip -q install --upgrade pip setuptools &&\
     ./venv/bin/pip -q install ordered-set python-dateutil six weakrefmethod &&\
     ./venv/bin/pip -q install ./app/files/scripts/misp-stix &&\
     ./venv/bin/pip -q install ./PyMISP &&\
@@ -75,7 +89,7 @@ RUN git config --global advice.detachedHead false &&\
     ./venv/bin/pip -q install lief &&\
     ./venv/bin/pip -q install zmq redis &&\
     ./venv/bin/pip -q install python-magic &&\
-    ./venv/bin/pip -q install plyara &&\
+    ./venv/bin/pip -q install plyara yara &&\
     cd PyMISP &&\
     git submodule foreach "git pull -q origin main || git pull -q origin master || exit 0" &&\
     /var/www/MISP/venv/bin/pip -q install /var/www/MISP/PyMISP/.[fileobjects,neo,openioc,virustotal,pdfexport] &&\
@@ -104,6 +118,7 @@ ENV CAKE="sudo -H -u www-data /var/www/MISP/app/Console/cake"
 
 COPY --from=php_build --chown=root:root /usr/local/lib/php/extensions/no-debug-non-zts-20190902/ /usr/local/lib/php/extensions/no-debug-non-zts-20190902/
 COPY --from=php_build --chown=root:root /usr/local/etc/php/ /usr/local/etc/php/
+COPY --from=python_build /usr/local /usr/local
 COPY --from=misp_build --chown=www-data:www-data /var/www/ /var/www
 COPY --chown=root:root apache.conf /etc/apache2/sites-enabled/000-default.conf
 COPY --chown=root:root scripts/ /opt/scripts
@@ -112,7 +127,7 @@ COPY --chown=root:root scripts/ /opt/scripts
 RUN apt -qy update &&\
     apt -qy upgrade apache2 &&\
     apt -qy install --no-install-recommends git gnupg iputils-ping libfuzzy2 libgpgme11 libpng16-16 librdkafka1 libzip4\
-    mariadb-client python3 ssdeep sudo uuid &&\
+    mariadb-client ssdeep sudo uuid &&\
     rm -rf /var/lib/apt/lists/* &&\
     a2dismod status &&\
     a2enmod ssl rewrite headers setenvif &&\

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -76,8 +76,8 @@ setup_smtp() {
 restore_persistence() {
     echo "Restoring persistent file storage..."
     cd /var/www/
-    mkdir -p MISPData/attachments MISPData/config MISPData/files MISPData/icons MISPData/images MISPData/logs\
-        MISPData/tmp
+    mkdir -p MISPData/attachments MISPData/config MISPData/custom_scripts MISPData/files MISPData/icons MISPData/images\
+        MISPData/logs MISPData/tmp
 
     if [ ! -L MISP/app/Config ]; then
         echo "Persisting config..."

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -168,11 +168,13 @@ initial_config() {
         );
     }" >MISP/app/Config/database.php
 
+    echo "Setting file ownership and permissions..."
     chown -R www-data: /var/www/MISP/
     chown -R www-data: /var/www/MISPData/
     chown -R www-data: /var/www/MISPGnuPG/
     chmod -R 750 /var/www/MISP/app/Config/
 
+    echo "Generating encryption salt value..."
     SALT=$(openssl rand -base64 32)
     $CAKE Admin setSetting "Security.salt" "$SALT"
     $CAKE userInit -q
@@ -323,5 +325,5 @@ $CAKE Admin runUpdates
 rm /var/www/MISPData/.init_lock
 echo "Released startup lock."
 # Start MISP
-echo "Starting MISP..."
+echo "Starting MISP at $MISP_URL..."
 source /etc/apache2/envvars && exec /usr/sbin/apache2 -D FOREGROUND

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -175,17 +175,18 @@ initial_config() {
     chmod -R 750 /var/www/MISP/app/Config/
 
     echo "Generating encryption salt value..."
-    SALT=$(openssl rand -base64 32)
-    $CAKE Admin setSetting "Security.salt" "$SALT"
-    $CAKE userInit -q
+    $CAKE Admin setSetting "Security.salt" "$(openssl rand -base64 32)" 2>&1 >/dev/null
+    $CAKE userInit -q 2>&1 >/dev/null
+    $CAKE Admin setSetting "Security.advanced_authkeys" false
+    python3 /opt/scripts/set_auth_key.py -k "$($CAKE Admin getAuthKey admin@admin.test 2>&1)" 2>&1 >/dev/null
     $CAKE Admin setSetting "MISP.baseurl" "$MISP_URL"
     $CAKE Admin setSetting "MISP.external_baseurl" "$MISP_URL"
     $CAKE Admin setSetting "MISP.uuid" "$(uuid -v 4)"
     $CAKE Admin setSetting "MISP.redis_host" "$REDIS_HOST"
     $CAKE Admin setSetting "MISP.redis_database" "$REDIS_MISP_DB"
-    $CAKE Admin setSetting "MISP.redis_password" "$REDIS_PASSWORD"
+    $CAKE Admin setSetting "MISP.redis_password" "$REDIS_PASSWORD" 2>&1 >/dev/null
     $CAKE Admin setSetting "GnuPG.email" "$MISP_EMAIL_ADDRESS"
-    $CAKE Admin setSetting "GnuPG.password" "$GPG_PASSPHRASE"
+    $CAKE Admin setSetting "GnuPG.password" "$GPG_PASSPHRASE" 2>&1 >/dev/null
     $CAKE Admin setSetting "GnuPG.binary" "$(which gpg)"
     $CAKE Admin setSetting "MISP.email" "$MISP_EMAIL_ADDRESS"
     $CAKE Admin setSetting "MISP.contact" "$MISP_EMAIL_ADDRESS"
@@ -195,9 +196,9 @@ initial_config() {
     $CAKE Admin setSetting "Plugin.Action_services_url" "http://$MODULES_HOSTNAME"
     $CAKE Admin setSetting "SimpleBackgroundJobs.redis_host" "$REDIS_HOST"
     $CAKE Admin setSetting "SimpleBackgroundJobs.redis_database" "$REDIS_WORKER_DB"
-    $CAKE Admin setSetting "SimpleBackgroundJobs.redis_password" "$REDIS_PASSWORD"
+    $CAKE Admin setSetting "SimpleBackgroundJobs.redis_password" "$REDIS_PASSWORD" 2>&1 >/dev/null
     $CAKE Admin setSetting "SimpleBackgroundJobs.supervisor_host" "$WORKERS_HOSTNAME"
-    $CAKE Admin setSetting "SimpleBackgroundJobs.supervisor_password" "$WORKERS_PASSWORD"
+    $CAKE Admin setSetting "SimpleBackgroundJobs.supervisor_password" "$WORKERS_PASSWORD" 2>&1 >/dev/null
     $CAKE Admin setSetting "SimpleBackgroundJobs.enabled" true
     $CAKE Admin setSetting "MISP.org" "$ORG_NAME"
     /opt/scripts/misp-base-config.sh
@@ -207,8 +208,7 @@ initial_config() {
     /wait-for-it.sh -h "${WORKERS_HOSTNAME:-misp_workers}" -p 9001 -t 0 -- echo "Workers up"
 
     $CAKE Admin runUpdates
-    DB_KEY=$(openssl rand -base64 32)
-    $CAKE Admin setSetting "Security.encryption_key" "$DB_KEY"
+    $CAKE Admin setSetting "Security.encryption_key" "$(openssl rand -base64 32)" 2>&1 >/dev/null
     $CAKE Admin setSetting "MISP.email_from_name" "$MISP_EMAIL_NAME"
     $CAKE Admin setSetting "Plugin.Enrichment_clamav_connection" "${CLAMAV_HOSTNAME}:3310"
     /opt/scripts/misp-post-update-config.sh

--- a/misp-web/scripts/misp-base-config.sh
+++ b/misp-web/scripts/misp-base-config.sh
@@ -174,10 +174,6 @@ $CAKE Admin setSetting "MISP.event_alert_republish_ban_threshold" 5
 $CAKE Admin setSetting "MISP.event_alert_republish_ban_refresh_on_retry" false
 $CAKE Admin setSetting "MISP.incoming_tags_disabled_by_default" false
 $CAKE Admin setSetting "MISP.maintenance_message" "Great things are happening! MISP is undergoing maintenance, but will return shortly. You can contact the administration at \$email."
-$CAKE Admin setSetting "MISP.footermidleft" "This is an initial install"
-$CAKE Admin setSetting "MISP.footermidright" "Please configure and harden accordingly"
-$CAKE Admin setSetting "MISP.welcome_text_top" "Initial Install, please configure"
-$CAKE Admin setSetting "MISP.welcome_text_bottom" "Welcome to MISP, change this message in MISP Settings"
 $CAKE Admin setSetting "MISP.attachments_dir" "/var/www/MISPData/attachments"
 $CAKE Admin setSetting "MISP.download_attachments_on_load" true
 $CAKE Admin setSetting "MISP.event_alert_metadata_only" false
@@ -191,7 +187,6 @@ $CAKE Admin setSetting "debug" 0
 $CAKE Admin setSetting "Security.auth_enforced" false
 $CAKE Admin setSetting "Security.log_each_individual_auth_fail" false
 $CAKE Admin setSetting "Security.rest_client_baseurl" ""
-$CAKE Admin setSetting "Security.advanced_authkeys" false
 $CAKE Admin setSetting "Security.password_policy_length" 12
 $CAKE Admin setSetting "Security.password_policy_complexity" '/^((?=.*\d)|(?=.*\W+))(?![\n])(?=.*[A-Z])(?=.*[a-z]).*$|.{16,}/'
 # Appease the security audit, #hardening

--- a/misp-web/scripts/misp_maintenance_jobs.ini
+++ b/misp-web/scripts/misp_maintenance_jobs.ini
@@ -1,0 +1,13 @@
+[DEFAULT]
+authkey = 0000000000000000000000000000000000000000
+baseurl = hxxp://misp-web
+debug = False
+verifytls = False
+
+[update_objects]
+command = /bin/bash /opt/scripts/update_objects.sh
+enabled = True
+interval = 1440
+lastrun = 0
+needsauthkey = False
+

--- a/misp-web/scripts/misp_maintenance_runner.py
+++ b/misp-web/scripts/misp_maintenance_runner.py
@@ -140,7 +140,7 @@ while True:
         test = urlparse(baseUrl)
         # As urlparse splits a URL without validation, do manual validation of the result.
         if test.scheme not in ["http", "https"] or not IsValidDomain(
-            test.netloc, AllowIP=True
+            test.hostname, AllowIP=True
         ):
             raise ValueError()
     except Exception as e:

--- a/misp-web/scripts/misp_maintenance_runner.py
+++ b/misp-web/scripts/misp_maintenance_runner.py
@@ -132,7 +132,7 @@ while True:
         continue
 
     if logger == None:
-        logger = CreateLogger(config.get("DEFAULT", "debug", fallback=True))
+        logger = CreateLogger(config.getboolean("DEFAULT", "debug", fallback=True))
         logger.info("Starting maintenance job scheduler")
 
     try:

--- a/misp-web/scripts/misp_maintenance_runner.py
+++ b/misp-web/scripts/misp_maintenance_runner.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+
+"""Wrapper to to run MISP maintenance jobs"""
+
+# SPDX-FileCopyrightText: 2023 Jisc Services Limited
+# SPDX-FileContributor: Joe Pitt
+#
+# SPDX-License-Identifier: GPL-3.0-only
+
+from configparser import ConfigParser
+from ipaddress import ip_address, IPv6Address
+from logging import DEBUG, Formatter, getLogger, INFO, Logger
+from logging.handlers import RotatingFileHandler
+from os import environ
+from os.path import isfile
+from re import compile as regex
+from shutil import copy
+from subprocess import DEVNULL, Popen
+from time import sleep, time
+from urllib.parse import urlparse
+
+
+__author__ = "Joe Pitt"
+__copyright__ = "Copyright 2023, Jisc Services Limited"
+__email__ = "Joe.Pitt@jisc.ac.uk"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Joe Pitt"
+__status__ = "Production"
+__version__ = "1.0.0"
+
+AuthKeyRegEx = regex(r"^[0-9A-z]{40}$")
+# Regular expression by Tim Groeneveld, Nov 18, 2014, https://stackoverflow.com/a/26987741
+DomainNameRegEx = regex(
+    r"^(((?!-))(xn--|_)?[a-z0-9-]{0,61}[a-z0-9]{1,1}\.)*"
+    r"(xn--)?([a-z0-9][a-z0-9\-]{0,60}|[a-z0-9-]{1,30}"
+    r"\.[a-z]{2,})$"
+)
+
+
+def CreateLogger(Debug: bool = False) -> Logger:
+    """Initialise a Logger for the job runner, using a self rotating log file.
+
+    Returns:
+        Logger: A configured logging endpoint for the job runner.
+    """
+
+    TALogger = getLogger("misp_maintenance_runner")
+    TALogger.propagate = False
+    if Debug:
+        TALogger.setLevel(DEBUG)
+    else:
+        TALogger.setLevel(INFO)
+    # Build the Splunk AppInspect compliant log file path.
+    LogPath = "/var/www/MISPData/logs/misp_maintenance_runner.log"
+
+    # Prevent the log from growing beyond 20MB
+    LogHandler = RotatingFileHandler(LogPath, maxBytes=20000000)
+    LogFormatter = Formatter(
+        "%(asctime)s {} %(name)s[%(process)d]: [%(levelname)s] %(message)s".format(
+            environ["FQDN"]
+        ),
+        "%b %d %H:%M:%S",
+    )
+    LogHandler.setFormatter(LogFormatter)
+    TALogger.addHandler(LogHandler)
+    return TALogger
+
+
+def IsValidDomain(Domain: str, AllowIP: bool = False) -> bool:
+    """Check if a string is a valid domain name.
+
+    Args:
+        Domain (str): The string to test.
+        AllowIP (bool): If IP addresses should be considered valid. Defaults to False.
+
+    Returns:
+        bool: Whether the domain is valid domain or not.
+    """
+    # For validation, make the domain name lowercase and encode any unicode characters using the Internationalized
+    # Domain Names in Applications (IDNA) protocol (i.e. into xn-- format).
+    Domain = Domain.lower().encode("idna").decode("utf-8")
+    if DomainNameRegEx.match(Domain):
+        # The string is a valid domain or IPv4 address
+        if AllowIP:
+            return True
+        else:
+            try:
+                ip_address(Domain)
+                # The string is a valid IPv4 address
+                return False
+            except:
+                # The string is a valid domain
+                return True
+    else:
+        # the string isn't a valid domain or IPv4 address
+        if AllowIP:
+            if Domain[0] == "[" and Domain[-1] == "]":
+                # strip URL wrapping of IPv6 addresses
+                Domain = Domain[1:-1]
+            try:
+                return type(ip_address(Domain)) == IPv6Address
+                # Only valid if the string is a valid IPv6 address, not an IPv4 address
+            except:
+                # The string isn't a valid IPv6 address
+                return False
+        else:
+            return False
+
+
+configFile = "/var/www/MISPData/misp_maintenance_jobs.ini"
+if not isfile(configFile):
+    copy("/opt/scripts/misp_maintenance_jobs.ini", configFile)
+
+config = ConfigParser()
+logger = None
+while True:
+    now = time()
+    if logger != None:
+        logger.debug("Re-reading config file")
+    # count of successfully parsed configuration files
+    if len(config.read(configFile)) == 0:
+        if logger != None:
+            logger.critical(
+                "Config file is corrupt cannot continue, waiting 5 minutes to try again"
+            )
+        else:
+            print(
+                "Config file is corrupt cannot continue, waiting 5 minutes to try again"
+            )
+        # wait five minutes then retry
+        sleep(300)
+        continue
+
+    if logger == None:
+        logger = CreateLogger(config.get("DEFAULT", "debug", fallback=True))
+        logger.info("Starting maintenance job scheduler")
+
+    try:
+        baseUrl = config.get("DEFAULT", "baseUrl")
+        test = urlparse(baseUrl)
+        # As urlparse splits a URL without validation, do manual validation of the result.
+        if test.scheme not in ["http", "https"] or not IsValidDomain(
+            test.netloc, AllowIP=True
+        ):
+            raise ValueError()
+    except Exception as e:
+        logger.error(
+            "Configured Base URL is invalid, reverting to https://{}:{} without TLS verification".format(
+                environ["FQDN"], environ["HTTPS_PORT"]
+            )
+        )
+        config.set(
+            "DEFAULT",
+            "baseUrl",
+            "https://{}:{}".format(environ["FQDN"], environ["HTTPS_PORT"]),
+        )
+        config.set("DEFAULT", "verifyTls", "False")
+        with open(configFile, "w") as f:
+            config.write(f)
+
+    try:
+        authKey = config.get("DEFAULT", "authKey")
+        if not AuthKeyRegEx.match(authKey):
+            raise ValueError()
+    except Exception as e:
+        logger.error("Configured AuthKey is invalid, clearing it")
+        config.set(
+            "DEFAULT",
+            "authKey",
+            "0000000000000000000000000000000000000000",
+        )
+        with open(configFile, "w") as f:
+            config.write(f)
+
+    try:
+        verifyTls = config.getboolean("DEFAULT", "verifyTls")
+    except Exception as e:
+        logger.error("Invalid boolean value for Verify TLS, reverting to False")
+        config.set("DEFAULT", "verifyTls", "False")
+        with open(configFile, "w") as f:
+            config.write(f)
+
+    for job in config.sections():
+        logger.debug("Processing job: {}".format(job))
+        try:
+            if config.getboolean(job, "enabled"):
+                # configuration interval is in minutes, script interval is in seconds
+                interval = config.getint(job, "interval") * 60
+                # stored as UNIX Epoch time
+                lastRun = config.getint(job, "lastRun")
+                # if time since last run is greater or equal to interval
+                if now - lastRun >= interval:
+                    if (
+                        config.getboolean(job, "needsAuthKey")
+                        and config.get("DEFAULT", "authKey")
+                        == "0000000000000000000000000000000000000000"
+                    ):
+                        logger.error(
+                            "{} skipped: a valid AuthKey is required but not present".format(
+                                job
+                            )
+                        )
+                    else:
+                        logger.info("Triggering job: {}".format(job))
+                        # fire and forget the job - it should have its own logging
+                        Popen(
+                            ["sh", "-c", config.get(job, "command")],
+                            stderr=DEVNULL,
+                            stdout=DEVNULL,
+                        )
+                        logger.debug("Job {} triggered successfully".format(job))
+                    # update the config with the last run time, rounded to the closest second
+                    config.set(job, "lastRun", str(int(now)))
+                else:
+                    logger.debug("Job {} is not due yet".format(job))
+            else:
+                logger.debug("Job {} is disabled".format(job))
+        except Exception as e:
+            logger.error("Error processing job {}: ({}) {}".format(job, type(e), e))
+
+    logger.debug("Writing back config file")
+    with open(configFile, "w") as f:
+        config.write(f)
+
+    # wait 1 minute before re-running
+    sleep(60)

--- a/misp-web/scripts/run_misp_sync_jobs.py
+++ b/misp-web/scripts/run_misp_sync_jobs.py
@@ -69,7 +69,6 @@ debug = config.getboolean("DEFAULT", "debug")
 
 MISPLogger = CreateLogger(debug)
 MISPLogger.info("Starting sync script")
-MISPLogger.info("Connecting to MISP API")
 
 MISPLogger.debug("Checking for mutex")
 Mutex = "/var/www/MISPData/tmp/run_misp_sync_jobs.pid"
@@ -101,6 +100,7 @@ with open(Mutex, "w") as f:
     f.write(str(getpid()))
     MISPLogger.debug("Mutex obtained")
 
+MISPLogger.info("Connecting to MISP API")
 try:
     misp = PyMISP(baseUrl, authKey, verifyTls)
 except Exception as e:

--- a/misp-web/scripts/set_auth_key.py
+++ b/misp-web/scripts/set_auth_key.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+"""Import initial auth key"""
+
+# SPDX-FileCopyrightText: 2023 Jisc Services Limited
+# SPDX-FileContributor: Joe Pitt
+#
+# SPDX-License-Identifier: GPL-3.0-only
+
+from argparse import ArgumentParser, ArgumentTypeError
+from configparser import ConfigParser
+from os.path import isfile
+from re import compile
+from shutil import copy
+
+
+__author__ = "Joe Pitt"
+__copyright__ = "Copyright 2023, Jisc Services Limited"
+__email__ = "Joe.Pitt@jisc.ac.uk"
+__license__ = "GPL-3.0-only"
+__maintainer__ = "Joe Pitt"
+__status__ = "Production"
+__version__ = "1.0.0"
+
+
+def AuthKeyType(AuthKey: str) -> str:
+    """Check the Auth Key has the correct format
+
+    Args:
+        AuthKey (str): The Auth Key passed on the command line
+
+    Raises:
+        ArgumentTypeError: The Auth Key is invalid
+
+    Returns:
+        str: The Auth Key if it is valid
+    """
+    if not compile(r"^[0-9A-z]{40}$").match(AuthKey):
+        raise ArgumentTypeError("invalid value")
+    return AuthKey
+
+
+Parser = ArgumentParser()
+Parser.add_argument("-k", "--auth-key", dest="key", required=True, type=AuthKeyType)
+Arguments = Parser.parse_args()
+
+configFile = "/var/www/MISPData/misp_maintenance_jobs.ini"
+if not isfile(configFile):
+    copy("/opt/scripts/misp_maintenance_jobs.ini", configFile)
+
+Config = ConfigParser()
+Config.read(configFile)
+Config.set("DEFAULT", "authKey", Arguments.key)
+with open(configFile, "w") as f:
+    Config.write(f)

--- a/misp-workers/misp-workers.conf
+++ b/misp-workers/misp-workers.conf
@@ -88,3 +88,16 @@ startretries=10
 stderr_logfile=/var/www/MISPData/tmp/logs/misp-workers-errors.log
 stdout_logfile=/var/www/MISPData/tmp/logs/misp-workers.log
 user=www-data
+
+[program:maintenance]
+autorestart=true
+autostart=true
+command=/var/www/MISP/venv/bin/python3 /opt/scripts/misp_maintenance_runner.py
+directory=/var/www/MISP
+numprocs=1
+process_name=%(program_name)s_%(process_num)02d
+redirect_stderr=false
+startretries=10
+stderr_logfile=/var/www/MISPData/logs/misp_maintenance_supervisor-errors.log
+stdout_logfile=/var/www/MISPData/logs/misp_maintenance_supervisor.log
+user=root

--- a/misp-workers/misp-workers.conf
+++ b/misp-workers/misp-workers.conf
@@ -7,10 +7,11 @@
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 childlogdir=/var/log/supervisor
-nodaemon = true
+nodaemon=true
+user=root
 
 [rpcinterface:supervisor]
-supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 
 [unix_http_server]
 file=/var/run/supervisor.sock


### PR DESCRIPTION
# Description

Implements the extensible `misp_maintenance_jobs` system to automatically configure and run common maintenance tasks, initially:

* Updating MISP objects such as galaxies and warning lists, and
* Server synchronisation tasks: pushing, pulling, and caching remote feeds and servers.

The system also allows the addition of custom tasks.

Also fix:
* README badges showing dev images,
* Building dev workers using production web as `FROM`,
* Python 3.9 no longer being supported by MISP,
* Secrets being revealed in container start up logs,
* CI/CD failing if MISP/misp-modules does not have a tag matching MISP/MISP, and
* Some settings being set twice times during initial setup.

## Related Issue(s)

(none)

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.
- [x] Built-in maintenance tasks run successfully.
- [x] Custom maintenance tasks are picked up and run successfully.

**Test Configuration**:
* Docker Host OS: Ubuntu 22.04.3 LTS
* Docker Engine Version: 24.0.6
* MISP Version: 2.4.177

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
