### PR TITLE
fix: environment variables loop

### DIFF
--- a/misp-web/scripts/misp_maintenance_runner.py
+++ b/misp-web/scripts/misp_maintenance_runner.py
@@ -176,7 +176,7 @@ while True:
 
     try:
         debug = config.getboolean("DEFAULT", "debug")
-    except:
+    except Exception:
         logger.error("Invalid boolean value for Debug, reverting to False")
         config.set("DEFAULT", "debug", "False")
         debug = False


### PR DESCRIPTION
# Description

Add waits for Redis, MISP Modules, and ClamAV to start during environment variable enforcement to correct a crash loop which could occur in MISP Web until those services were up.

## Related Issue(s)

(none) 

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.
- [x] Manual deployment of old image then upgrading to these dev image.

**Test Configuration**:
* Docker Host OS: Ubuntu 22.04.3 LTS
* Docker Engine Version: 24.0.7
* MISP Version: 2.4.178

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
