### PR TITLE
Disambiguate GitHub Actions Jobs

### DIFF
--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -14,7 +14,7 @@ env:
   COMPOSE_PROJECT_NAME: misp_dev
 jobs:
   run-dev:
-    name: Build, Test, and Release
+    name: Build, Test, and Release (Dev)
     runs-on: ubuntu-latest
     steps:
       # Environment Setup


### PR DESCRIPTION
# Description

Disambiguate GitHub Actions job names to allow enforcing check passing in `main` branch protection rule.

## Related Issue(s)

(none)

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.

**Test Configuration**:
* Docker Host OS: Ubuntu 22.04.3 LTS
* Docker Engine Version: 24.0.7
* MISP Version: 2.4.178

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
