### PR TITLE
Fix Online Version Check

### DIFF
--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -60,7 +60,7 @@ WORKDIR /var/www/
 RUN git config --global advice.detachedHead false &&\
     git clone -q --branch ${MISP_VERSION} --single-branch https://github.com/MISP/MISP &&\
     cd MISP &&\
-    echo "$(git rev-parse ${MISP_VERSION})" > .git_commit_version &&\
+    git rev-parse ${MISP_VERSION} > .git_commit_version &&\
     git submodule update -q --init --recursive &&\
     git submodule foreach --recursive git config core.filemode false &&\
     git config core.filemode false

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -27,8 +27,8 @@ RUN apt-get -qy update &&\
     ./configure &&\
     make install &&\
     docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp &&\
-    docker-php-ext-install gd &&\
-    docker-php-ext-enable apcu brotli gd gnupg rdkafka redis simdjson ssdeep
+    docker-php-ext-install gd gettext sockets &&\
+    docker-php-ext-enable apcu brotli gd gettext gnupg rdkafka redis simdjson sockets ssdeep
 
 # Build Python 3.10
 FROM debian:bullseye AS python_build

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -64,6 +64,7 @@ WORKDIR /var/www/
 RUN git config --global advice.detachedHead false &&\
     git clone -q --branch ${MISP_VERSION} --single-branch https://github.com/MISP/MISP &&\
     cd MISP &&\
+    echo "$(git rev-parse ${MISP_VERSION})" > .git_commit_version &&\
     git submodule update -q --init --recursive &&\
     git submodule foreach --recursive git config core.filemode false &&\
     git config core.filemode false &&\
@@ -96,11 +97,14 @@ RUN git config --global advice.detachedHead false &&\
     git submodule foreach "git pull -q origin main || git pull -q origin master || exit 0" &&\
     /var/www/MISP/venv/bin/pip -q install --no-cache-dir /var/www/MISP/PyMISP/.[fileobjects,openioc,virustotal,pdfexport] &&\
     cd /var/www/ &&\
+    find /var/www -type d -name .git -exec rm -r {} + &&\
+    mkdir MISP/.git &&\
+    mv MISP/.git_commit_version MISP/.git/HEAD &&\
+    cp MISP/.git/HEAD MISP/.git/ORIG_HEAD &&\
     chown -R www-data: MISP &&\
     chmod -R 750 MISP &&\
     chmod -R g+ws MISP/app/tmp &&\
     chmod -R g+ws MISP/app/files &&\
-    find /var/www -type d -name .git -exec rm -r {} + &&\
     cd /var/www/MISP/app/files/ &&\
     rm -rf misp-decaying-models misp-galaxy misp-objects misp-workflow-blueprints noticelists taxonomies warninglists
 

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -12,45 +12,41 @@ COPY --chown=root:root php.ini /usr/local/etc/php/php.ini
 RUN apt-get -qy update &&\
     apt-get -qy install --no-install-recommends git libc6 libcurl4-openssl-dev libfuzzy-dev libfreetype-dev libgd3 \
     libicu-dev libjpeg-dev libgpgme-dev libpng-dev librdkafka-dev libwebp-dev libzip-dev &&\
-    docker-php-ext-install bcmath curl gd intl json mysqli opcache pcntl pdo_mysql zip &&\
-    pecl install apcu &&\
+    docker-php-ext-install bcmath curl gd intl json mysqli opcache pcntl pdo_mysql zip
+RUN pecl install apcu &&\
     pecl install gnupg &&\
     pecl install rdkafka &&\
     pecl install redis &&\
     pecl install simdjson &&\
     ln -s /usr/lib/x86_64-linux-gnu/libfuzzy.so /usr/lib/libfuzzy.so &&\
     ldconfig &&\
-    pecl install ssdeep &&\
-    git clone -q --recursive --depth=1 https://github.com/kjdev/php-ext-brotli.git &&\
+    pecl install ssdeep
+RUN git clone -q --recursive --depth=1 https://github.com/kjdev/php-ext-brotli.git &&\
     cd php-ext-brotli &&\
     phpize &&\
     ./configure &&\
-    make install &&\
-    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp &&\
+    make install
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp &&\
     docker-php-ext-install gd gettext sockets &&\
     docker-php-ext-enable apcu brotli gd gettext gnupg rdkafka redis simdjson sockets ssdeep
 
 # Build Python 3.10
 FROM debian:bullseye AS python_build
-RUN apt-get -yq update
-RUN apt-get -yq install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev
+RUN apt-get -yq update &&\
+    apt-get -yq install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev\
+    libffi-dev libsqlite3-dev wget libbz2-dev
 WORKDIR /opt/
-RUN wget --progress=dot:giga https://www.python.org/ftp/python/3.10.12/Python-3.10.12.tgz
-RUN tar xfz Python-3.10.12.tgz
+RUN wget --progress=dot:giga https://www.python.org/ftp/python/3.10.12/Python-3.10.12.tgz &&\
+    tar xfz Python-3.10.12.tgz
 WORKDIR /opt/Python-3.10.12
-RUN ./configure --prefix=/usr/local --enable-optimizations
-RUN make
-RUN make install
+RUN ./configure --prefix=/usr/local --enable-optimizations &&\
+    make &&\
+    make install
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools
 
 # Build MISP
 FROM php:7.4-apache AS misp_build
 ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
-
-COPY --from=php_build --chown=root:root /usr/local/lib/php/extensions/no-debug-non-zts-20190902/ \
-    /usr/local/lib/php/extensions/no-debug-non-zts-20190902/
-COPY --from=php_build --chown=root:root /usr/local/etc/php/ /usr/local/etc/php/
-COPY --from=python_build /usr/local /usr/local
 
 # Install build dependencies
 RUN apt-get -qy update &&\
@@ -67,9 +63,15 @@ RUN git config --global advice.detachedHead false &&\
     echo "$(git rev-parse ${MISP_VERSION})" > .git_commit_version &&\
     git submodule update -q --init --recursive &&\
     git submodule foreach --recursive git config core.filemode false &&\
-    git config core.filemode false &&\
-    cd app &&\
-    php composer.phar -q self-update &&\
+    git config core.filemode false
+
+COPY --from=php_build --chown=root:root /usr/local/lib/php/extensions/no-debug-non-zts-20190902/ \
+    /usr/local/lib/php/extensions/no-debug-non-zts-20190902/
+COPY --from=php_build --chown=root:root /usr/local/etc/php/ /usr/local/etc/php/
+COPY --from=python_build /usr/local /usr/local
+
+WORKDIR /var/www/MISP/app
+RUN php composer.phar -q self-update &&\
     php composer.phar -q config --no-plugins allow-plugins.composer/installers true &&\
     php composer.phar -q config --no-plugins allow-plugins.php-http/discovery true &&\
     php composer.phar -q install --no-dev &&\
@@ -80,9 +82,9 @@ RUN git config --global advice.detachedHead false &&\
     elasticsearch/elasticsearch \
     aws/aws-sdk-php \
     jakub-onderka/openid-connect-php \
-    php-http/message-factory &&\
-    cd .. &&\
-    cp -fa INSTALL/setup/config.php app/Plugin/CakeResque/Config/config.php &&\
+    php-http/message-factory
+WORKDIR /var/www/MISP
+RUN cp -fa INSTALL/setup/config.php app/Plugin/CakeResque/Config/config.php &&\
     python3 -m venv venv &&\
     ./venv/bin/pip -q install --no-cache-dir --upgrade pip setuptools &&\
     ./venv/bin/pip -q install --no-cache-dir ordered-set python-dateutil six weakrefmethod &&\
@@ -95,9 +97,9 @@ RUN git config --global advice.detachedHead false &&\
     ./venv/bin/pip -q install --no-cache-dir plyara yara &&\
     cd PyMISP &&\
     git submodule foreach "git pull -q origin main || git pull -q origin master || exit 0" &&\
-    /var/www/MISP/venv/bin/pip -q install --no-cache-dir /var/www/MISP/PyMISP/.[fileobjects,openioc,virustotal,pdfexport] &&\
-    cd /var/www/ &&\
-    find /var/www -type d -name .git -exec rm -r {} + &&\
+    /var/www/MISP/venv/bin/pip -q install --no-cache-dir /var/www/MISP/PyMISP/.[fileobjects,openioc,virustotal,pdfexport]
+WORKDIR /var/www
+RUN find /var/www -type d -name .git -exec rm -r {} + &&\
     mkdir MISP/.git &&\
     mv MISP/.git_commit_version MISP/.git/HEAD &&\
     cp MISP/.git/HEAD MISP/.git/ORIG_HEAD &&\
@@ -121,26 +123,24 @@ EXPOSE 80 443
 
 ENV CAKE="sudo -H -u www-data /var/www/MISP/app/Console/cake"
 
+# Install runtime dependencies
+RUN apt-get -qy update &&\
+    apt-get -qy upgrade apache2 &&\
+    apt-get -qy install --no-install-recommends git gnupg iputils-ping libfuzzy2 libgd3 libgpgme11 libpng16-16 librdkafka1\
+    libzip4 mariadb-client ssdeep sudo uuid &&\
+    rm -rf /var/lib/apt/lists/*
+
 COPY --from=php_build --chown=root:root /usr/local/lib/php/extensions/no-debug-non-zts-20190902/ /usr/local/lib/php/extensions/no-debug-non-zts-20190902/
 COPY --from=php_build --chown=root:root /usr/local/etc/php/ /usr/local/etc/php/
 COPY --from=python_build /usr/local /usr/local
 COPY --from=misp_build --chown=www-data:www-data /var/www/ /var/www
 COPY --chown=root:root apache.conf /etc/apache2/sites-enabled/000-default.conf
 COPY --chown=root:root scripts/ /opt/scripts
-
-# Install runtime dependencies
-RUN apt-get -qy update &&\
-    apt-get -qy upgrade apache2 &&\
-    apt-get -qy install --no-install-recommends git gnupg iputils-ping libfuzzy2 libgd3 libgpgme11 libpng16-16 librdkafka1\
-    libzip4 mariadb-client ssdeep sudo uuid &&\
-    rm -rf /var/lib/apt/lists/* &&\
-    a2dismod status &&\
-    a2enmod ssl rewrite headers setenvif &&\
-    chmod +x /opt/scripts/*
-
-WORKDIR /var/www/MISP/
 COPY entrypoint.sh /entrypoint.sh
 COPY wait-for-it.sh /wait-for-it.sh
-RUN chmod 755 /*.sh
+RUN a2dismod status &&\
+    a2enmod ssl rewrite headers setenvif &&\
+    chmod +x /opt/scripts/* /*.sh
+WORKDIR /var/www/MISP/
 ENTRYPOINT /wait-for-it.sh -h ${MYSQL_HOSTNAME:-misp_db} -p 3306 -t 0 -- /entrypoint.sh
 HEALTHCHECK CMD curl -fk https://127.0.0.1/users/login || exit 1

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -284,9 +284,9 @@ initial_config() {
     fi
 
     # Set MISP Live
-    $CAKE Live 1
-    # Add new line after "MISP is now live. Users can now log in."
-    echo
+    $CAKE Live 1 >/dev/null 2>&1
+    echo "Maintenance mode disabled"
+    
     $CAKE Admin setSetting "MISP.server_settings_skip_backup_rotate" false
     echo "Initial configuration finished."
 }

--- a/misp-web/scripts/misp-post-update-config.sh
+++ b/misp-web/scripts/misp-post-update-config.sh
@@ -16,6 +16,3 @@ $CAKE Admin setSetting "MISP.store_api_access_time" true
 $CAKE Admin setSetting "MISP.thumbnail_in_redis" true
 $CAKE Admin setSetting "MISP.unpublishedprivate" false
 $CAKE Admin setSetting "Security.otp_required" true
-
-# Workaround diagnostics page issue introduced in v2.4.175 (https://github.com/MISP/MISP/pull/9230)
-$CAKE Admin setSetting "MISP.online_version_check" false

--- a/misp-workers/entrypoint.sh
+++ b/misp-workers/entrypoint.sh
@@ -55,11 +55,12 @@ restore_persistence() {
     echo "Persistent file storage created."
 }
 
-
-while [ ! -f /var/www/MISPData/.configured ]; do
-    echo "Waiting 5 seconds for misp_web to finish configuration..."
-    sleep 5
-done
+if [ ! -f /var/www/MISPData/.configured ]; then
+    echo "Waiting for misp_web to finish configuration..."
+    while [ ! -f /var/www/MISPData/.configured ]; do
+        sleep 5
+    done
+fi
 
 restore_persistence
 mkdir -p /var/www/MISPData/tmp/logs


### PR DESCRIPTION
# Description

Add `gettext` and `sockets` PHP extensions to enable online version checks.

Also:

* Keep minimal git info for diagnostics page
* Improve build cacheability of `misp-web`
* Reduce initial setup log size from `misp-workers`
* Clarify the maintenance mode log message during initial setup

## Related Issue(s)

* #2 - fixed

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.

**Test Configuration**:
* Docker Host OS: Ubuntu 22.04.3
* Docker Engine Version: 24.0.7
* MISP Version: 2.4.178

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
