### PR TITLE
fix: logs will not rotate

### DIFF
--- a/misp-web/scripts/log.py
+++ b/misp-web/scripts/log.py
@@ -18,7 +18,7 @@ __email__ = "Joe.Pitt@jisc.ac.uk"
 __license__ = "GPL-3.0-only"
 __maintainer__ = "Joe Pitt"
 __status__ = "Production"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 def CreateLogger(
@@ -58,7 +58,7 @@ def CreateLogger(
     )
 
     # Prevent the log from growing beyond 20MB
-    LogHandler = RotatingFileHandler(LogPath, maxBytes=20000000)
+    LogHandler = RotatingFileHandler(LogPath, maxBytes=20000000, backupCount=1)
     LogHandler.setFormatter(LogFormatter)
     logger.addHandler(LogHandler)
 


### PR DESCRIPTION
# Description

Add missing argument to `RotatingFileHandler` log handler.

## Related Issue(s)

* n/a

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.

**Test Configuration**:
* Docker Host OS: Ubuntu 22.04.3 LTS
* Docker Engine Version: 24.0.7
* MISP Version: v2.4.179

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
