### PR TITLE
fix: worker persistence & general fixes

### DIFF
--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -116,3 +116,4 @@ services:
     restart: unless-stopped
     volumes:
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
+      - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,3 +108,4 @@ services:
     restart: unless-stopped
     volumes:
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
+      - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG

--- a/misp-modules/Dockerfile
+++ b/misp-modules/Dockerfile
@@ -17,7 +17,7 @@ RUN git clone --branch ${MISP_VERSION} --single-branch https://github.com/MISP/m
     /usr/local/src/misp_modules
 WORKDIR /usr/local/src/misp_modules
 RUN python3 -m venv /misp_modules &&\
-    /misp_modules/bin/pip3 install --upgrade pip --no-cache-dir &&\
+    /misp_modules/bin/pip3 install --upgrade pip setuptools --no-cache-dir &&\
     /misp_modules/bin/pip3 install greynoise pyeti redis --no-cache-dir &&\
     /misp_modules/bin/pip3 install git+https://github.com/abenassi/Google-Search-API --no-cache-dir &&\
     /misp_modules/bin/pip3 install -I -r REQUIREMENTS --no-cache-dir &&\
@@ -34,7 +34,8 @@ EXPOSE 6666
 
 RUN apt-get update &&\
     apt-get install -y curl libgl1 libglib2.0-0 libpoppler-cpp0v5 libzbar0 &&\
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* &&\
+    python3 -m pip install --upgrade pip setuptools --no-cache-dir
 
 COPY --from=build /misp_modules/ /misp_modules/
 WORKDIR /misp_modules/bin/

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qy update &&\
     docker-php-ext-install bcmath curl gd intl json mysqli opcache pcntl pdo_mysql zip
 RUN pecl install apcu &&\
     pecl install gnupg &&\
+    pecl install mongodb &&\
     pecl install rdkafka &&\
     pecl install redis &&\
     pecl install simdjson &&\
@@ -28,7 +29,7 @@ RUN git clone -q --recursive --depth=1 https://github.com/kjdev/php-ext-brotli.g
     make install
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp &&\
     docker-php-ext-install gd gettext sockets &&\
-    docker-php-ext-enable apcu brotli gd gettext gnupg rdkafka redis simdjson sockets ssdeep
+    docker-php-ext-enable apcu brotli gd gettext gnupg mongodb rdkafka redis simdjson sockets ssdeep
 
 # Build Python 3.10
 FROM debian:bullseye AS python_build
@@ -71,18 +72,13 @@ COPY --from=php_build --chown=root:root /usr/local/etc/php/ /usr/local/etc/php/
 COPY --from=python_build /usr/local /usr/local
 
 WORKDIR /var/www/MISP/app
+ARG COMPOSER_ALLOW_SUPERUSER=1
 RUN php composer.phar -q self-update &&\
     php composer.phar -q config --no-plugins allow-plugins.composer/installers true &&\
     php composer.phar -q config --no-plugins allow-plugins.php-http/discovery true &&\
     php composer.phar -q install --no-dev &&\
-    php composer.phar -q require --with-all-dependencies supervisorphp/supervisor:^4.0 \
-    guzzlehttp/guzzle \
-    php-http/message \
-    lstrojny/fxmlrpc \
-    elasticsearch/elasticsearch \
-    aws/aws-sdk-php \
-    jakub-onderka/openid-connect-php \
-    php-http/message-factory
+    php composer.phar suggests --all | sed -nr 's/- (.+\/.+):/\1/p' | awk '{print $1}' | sort | uniq \
+        | xargs -i php composer.phar -q require --with-all-dependencies {}
 WORKDIR /var/www/MISP
 RUN cp -fa INSTALL/setup/config.php app/Plugin/CakeResque/Config/config.php &&\
     python3 -m venv venv &&\

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -78,7 +78,7 @@ RUN php composer.phar -q self-update &&\
     php composer.phar -q config --no-plugins allow-plugins.php-http/discovery true &&\
     php composer.phar -q install --no-dev &&\
     php composer.phar suggests --all | sed -nr 's/- (.+\/.+):/\1/p' | awk '{print $1}' | sort | uniq \
-        | xargs -i php composer.phar -q require --with-all-dependencies {}
+        | xargs -I {} php composer.phar -q require --with-all-dependencies {}
 WORKDIR /var/www/MISP
 RUN cp -fa INSTALL/setup/config.php app/Plugin/CakeResque/Config/config.php &&\
     python3 -m venv venv &&\

--- a/misp-web/scripts/misp-base-config.sh
+++ b/misp-web/scripts/misp-base-config.sh
@@ -86,7 +86,7 @@ $CAKE Admin setSetting "Plugin.S3_enable" false 2> /dev/null
 # Plugin CustomAuth tuneable
 $CAKE Admin setSetting "Plugin.CustomAuth_disable_logout" false
 # RPZ Plugin settings
-$CAKE Admin setSetting "Plugin.RPZ_policy" "DROP"
+$CAKE Admin setSetting "Plugin.RPZ_policy" 0
 $CAKE Admin setSetting "Plugin.RPZ_walled_garden" "127.0.0.1"
 $CAKE Admin setSetting "Plugin.RPZ_serial" "\$date00"
 $CAKE Admin setSetting "Plugin.RPZ_refresh" "2h"
@@ -164,8 +164,6 @@ $CAKE Admin setSetting "MISP.disable_user_add" false
 $CAKE Admin setSetting "MISP.block_event_alert" false
 $CAKE Admin setSetting "MISP.block_event_alert_tag" "no-alerts=\"true\""
 $CAKE Admin setSetting "MISP.block_old_event_alert" false
-$CAKE Admin setSetting "MISP.block_old_event_alert_age" ""
-$CAKE Admin setSetting "MISP.block_old_event_alert_by_date" ""
 $CAKE Admin setSetting "MISP.event_alert_republish_ban" false
 $CAKE Admin setSetting "MISP.event_alert_republish_ban_threshold" 5
 $CAKE Admin setSetting "MISP.event_alert_republish_ban_refresh_on_retry" false

--- a/misp-web/scripts/rotate_logs.py
+++ b/misp-web/scripts/rotate_logs.py
@@ -28,6 +28,7 @@ logs = [
     "/var/www/MISPData/tmp/logs/exec-errors.log",
     "/var/www/MISPData/tmp/logs/misp-workers-errors.log",
     "/var/www/MISPData/tmp/logs/misp-workers.log",
+    "/var/www/MISPData/tmp/logs/update_objects.log",
 ]
 
 for logFile in logs:

--- a/misp-web/scripts/update_objects.sh
+++ b/misp-web/scripts/update_objects.sh
@@ -5,58 +5,69 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-echo "Fixing permissions..."
-chown -R www-data: /var/www/
+DATE=(date +"%b %d %H:%M:%S")
+LOG=("${FQDN}" update_objects[$$]:)
 
-echo "Pulling MISP objects..."
+{
+    echo "$("${DATE[@]}")" "${LOG[@]}" Fixing permissions
+    chown -R www-data: /var/www/
+    echo "$("${DATE[@]}")" "${LOG[@]}" Fixed permissions
 
-(
-    cd /var/www/MISPData/files/misp-decaying-models || exit
-    echo "Updating misp-decaying-models..."
-    su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
-)
+    (
+        cd /var/www/MISPData/files/misp-decaying-models || exit
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulling misp-decaying-models
+        su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulled misp-decaying-models
+    )
 
-(
-    cd /var/www/MISPData/files/misp-galaxy || exit
-    echo "Updating misp-galaxy..."
-    su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
-)
+    (
+        cd /var/www/MISPData/files/misp-galaxy || exit
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulling misp-galaxy
+        su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulled misp-galaxy
+    )
 
-(
-    cd /var/www/MISPData/files/misp-objects || exit
-    echo "Updating misp-objects..."
-    su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
-)
+    (
+        cd /var/www/MISPData/files/misp-objects || exit
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulling misp-objects
+        su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulled misp-objects
+    )
 
-(
-    cd /var/www/MISPData/files/misp-workflow-blueprints || exit
-    echo "Updating misp-workflow-blueprints..."
-    su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
-)
+    (
+        cd /var/www/MISPData/files/misp-workflow-blueprints || exit
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulling misp-workflow-blueprints
+        su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulled misp-workflow-blueprints
+    )
 
-(
-    cd /var/www/MISPData/files/noticelists || exit
-    echo "Updating noticelists..."
-    su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
-)
+    (
+        cd /var/www/MISPData/files/noticelists || exit
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulling noticelists
+        su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulled noticelists
+    )
 
-(
-    cd /var/www/MISPData/files/taxonomies || exit
-    echo "Updating taxonomies..."
-    su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
-)
+    (
+        cd /var/www/MISPData/files/taxonomies || exit
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulling taxonomies
+        su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulled taxonomies
+    )
 
-(
-    cd /var/www/MISPData/files/warninglists || exit
-    echo "Updating warninglists..."
-    su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
-)
+    (
+        cd /var/www/MISPData/files/warninglists || exit
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulling warninglists
+        su www-data -s /bin/bash -c "git pull --quiet --ff-only origin main"
+        echo "$("${DATE[@]}")" "${LOG[@]}" Pulled warninglists
+    )
 
-echo "Loading updated MISP objects into database..."
-$CAKE admin updateGalaxies
-$CAKE admin updateObjectTemplates 1
-$CAKE admin updateNoticelists
-$CAKE admin updateTaxonomies
-$CAKE admin updateWarningLists
+    echo "$("${DATE[@]}")" "${LOG[@]}" Updating database
+    $CAKE admin updateGalaxies | xargs -L1 echo "$("${DATE[@]}")" "${LOG[@]}"
+    $CAKE admin updateObjectTemplates 1 | xargs -L1 echo "$("${DATE[@]}")" "${LOG[@]}"
+    $CAKE admin updateNoticelists | xargs -L1 echo "$("${DATE[@]}")" "${LOG[@]}"
+    $CAKE admin updateTaxonomies | xargs -L1 echo "$("${DATE[@]}")" "${LOG[@]}"
+    $CAKE admin updateWarningLists | xargs -L1 echo "$("${DATE[@]}")" "${LOG[@]}"
 
-echo "MISP objects updated."
+    echo "$("${DATE[@]}")" "${LOG[@]}" Done
+} | tee -a /var/www/MISPData/tmp/logs/update_objects.log

--- a/misp-workers/Dockerfile
+++ b/misp-workers/Dockerfile
@@ -19,6 +19,7 @@ VOLUME "/var/www/MISPData" "/var/www/MISPGnuPG"
 # Setup MISP Workers
 ARG DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 RUN apt-get -qy update &&\
+    apt-get -qy upgrade curl libtasn1-6 openssl libncurses6 libkrb5-3 gnutls-bin libxml2 systemd &&\
     apt-get -qy install git gnupg iputils-ping libfuzzy2 libgd3 libgpgme11 libpng16-16 librdkafka1\
     libzip4 mariadb-client ssdeep sudo supervisor uuid zip && \
     rm -rf /var/lib/apt/lists/*

--- a/misp-workers/Dockerfile
+++ b/misp-workers/Dockerfile
@@ -3,24 +3,37 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
-FROM jisccti/misp-web:${MISP_VERSION}
+ARG MISP_VERSION=0.0.0
+FROM jisccti/misp-web:${MISP_VERSION} as web
+FROM php:7.4-cli AS final
+ARG MISP_VERSION=0.0.0
 LABEL org.opencontainers.image.title="misp-workers" org.opencontainers.image.version=${MISP_VERSION}\
     org.opencontainers.image.ref.name="misp-workers"\
     org.opencontainers.image.description="Open Source Threat Intelligence and Sharing Platform."\
     org.opencontainers.image.authors="Jisc <CTI.Analysts@jisc.ac.uk"\
-    org.opencontainers.image.base.name="hub.docker.com/jisccti/misp-web:${MISP_VERSION}"
+    org.opencontainers.image.base.name="hub.docker.com/_/php:7.4-cli"
+ENV CAKE="sudo -H -u www-data /var/www/MISP/app/Console/cake"
+EXPOSE 9001
+VOLUME "/var/www/MISPData" "/var/www/MISPGnuPG"
 
 # Setup MISP Workers
+ARG DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 RUN apt-get -qy update &&\
-    apt-get -qy install supervisor && \
+    apt-get -qy install git gnupg iputils-ping libfuzzy2 libgd3 libgpgme11 libpng16-16 librdkafka1\
+    libzip4 mariadb-client ssdeep sudo supervisor uuid zip && \
     rm -rf /var/lib/apt/lists/*
 
+# Copy in dependencies and MISP
+COPY --from=web --chown=root:root /opt/scripts/ /opt/scripts
+COPY --from=web --chown=root:root /usr/local/ /usr/local/
+COPY --from=web --chown=root:root /wait-for-it.sh /wait-for-it.sh
+COPY --from=web --chown=www-data:www-data /var/www/ /var/www
+# Copy in worker specific items
 COPY misp-workers.conf /etc/supervisor/conf.d/misp-workers.conf
 COPY entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod 755 /*.sh
 
-EXPOSE 9001
+WORKDIR /var/www/MISP/
 ENTRYPOINT /wait-for-it.sh -h ${REDIS_HOST:-misp_redis} -p 6379 -t 0 -- /entrypoint.sh
 HEALTHCHECK --start-period=10m --timeout=5s CMD /healthcheck.sh

--- a/misp-workers/Dockerfile
+++ b/misp-workers/Dockerfile
@@ -21,5 +21,6 @@ COPY entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh
 RUN chmod 755 /*.sh
 
+EXPOSE 9001
 ENTRYPOINT /wait-for-it.sh -h ${REDIS_HOST:-misp_redis} -p 6379 -t 0 -- /entrypoint.sh
 HEALTHCHECK --start-period=10m --timeout=5s CMD /healthcheck.sh

--- a/misp-workers/entrypoint.sh
+++ b/misp-workers/entrypoint.sh
@@ -7,52 +7,49 @@
 
 restore_persistence() {
     echo "Restoring persistent file storage..."
-    cd /var/www/
-    set +e
-    mkdir -p MISPData/config MISPData/icons MISPData/images MISPData/files MISPData/tmp
+    cd /var/www/ || exit 1
 
-    if [ -d MISP/app/Config ]; then
-        #mv MISP/app/Config/* MISPData/config/
+    if [ ! -L MISP/app/Config ]; then
+        echo "Persisting config..."
         rm -rf MISP/app/Config
-    fi
-    if [ ! -L /var/www/MISP/app/Config ]; then
         ln -s /var/www/MISPData/config/ /var/www/MISP/app/Config
+    else
+        echo "Config already persistent."
     fi
 
-    if [ -d MISP/app/files ]; then
-        #mv MISP/app/files/* MISPData/files/
+    if [ ! -L MISP/app/files ]; then
+        echo "Persisting app files..."
         rm -rf MISP/app/files
-    fi
-    if [ ! -L /var/www/MISP/app/Config ]; then
         ln -s /var/www/MISPData/files/ /var/www/MISP/app/files
+    else
+        echo "App files already persistent."
     fi
 
-    if [ -d MISP/app/tmp ]; then
-        #mv MISP/app/tmp/* MISPData/tmp/
+    if [ ! -L MISP/app/tmp ]; then
+        echo "Persisting temp files..."
         rm -rf MISP/app/tmp
-    fi
-    if [ ! -L /var/www/MISP/app/tmp ]; then
         ln -s /var/www/MISPData/tmp/ /var/www/MISP/app/tmp
+    else
+        echo "Temp files already persistent."
     fi
 
-    if [ -d MISP/app/webroot/img/orgs ]; then
-        #mv MISP/app/webroot/img/orgs/* MISPData/icons/
+    if [ ! -L MISP/app/webroot/img/orgs ]; then
+        echo "Persisting org icons..."
         rm -rf MISP/app/webroot/img/orgs
-    fi
-    if [ ! -L /var/www/MISP/app/Config ]; then
         ln -s /var/www/MISPData/icons/ /var/www/MISP/app/webroot/img/orgs
+    else
+        echo "Org icons already persistent."
     fi
 
-    if [ -d MISP/app/webroot/img/custom ]; then
-        #mv MISP/app/webroot/img/custom/* MISPData/images/
+    if [ ! -L MISP/app/webroot/img/custom ]; then
+        echo "Persisting images..."
         rm -rf MISP/app/webroot/img/custom
-    fi
-    if [ ! -L /var/www/MISP/app/Config ]; then
         ln -s /var/www/MISPData/images/ /var/www/MISP/app/webroot/img/custom
+    else
+        echo "Images already persistent."
     fi
 
-    set -e
-    echo "Persistent file storage created."
+    echo "Persistent file storage restored."
 }
 
 if [ ! -f /var/www/MISPData/.configured ]; then


### PR DESCRIPTION
# Description

This PR:

* Addresses an issue with persisted files in the workers image which was preventing `update_objects.sh` from working.
* Removes Apache from the workers container and update image metadata to advertise the supervisor port 9001, not 80 and 443. 
* Adds logging to `update_objects.sh`.
* Installs compose modules based on `composer suggests --all` rather than hard coding.
* Patches `pip` and `setuptools` vulnerabilities identified by Docker Scout.
* Addresses settings that were being rejected during initial setup.

## Related Issue(s)

(none)

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.
- [x] Adding a custom taxonomy to the persistent storage gets loaded by `update_obects.sh`.
- [x] New `update_objects.log` file is populated as expected.
- [x] Patched vulnerabilities are cleared from the Docker Scout page of affected images.

**Test Configuration**:
* Docker Host OS: Rocky Linux release 9.2
* Docker Engine Version: 25.0.3
* MISP Version: v2.4.184

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
