### PR TITLE
fix: org icon move

### DIFF
--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Jisc Services Limited
 # SPDX-FileContributor: Joe Pitt
+# SPDX-FileContributor: James Ellor
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
@@ -37,7 +38,7 @@ jobs:
           sed -i 's/jisccti/${{ vars.DOCKERHUB_ORGANISATION }}/g' docker-compose.yml
           sed -i 's/latest/${{ env.BRANCH_NAME }}/g' docker-compose.yml
           sed -i 's/jisccti/${{ vars.DOCKERHUB_ORGANISATION }}/g' misp-workers/Dockerfile
-          sed -i 's/\\${MISP_VERSION}/${{ env.BRANCH_NAME }}/g' misp-workers/Dockerfile
+          sed -i 's/\${MISP_VERSION}/${{ env.BRANCH_NAME }}/g' misp-workers/Dockerfile
           cp example.env .env
           mkdir -p persistent/$COMPOSE_PROJECT_NAME/gpg persistent/$COMPOSE_PROJECT_NAME/tls
           cat <<EOF > persistent/$COMPOSE_PROJECT_NAME/gpg/import.asc

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -11,7 +11,7 @@ COPY --chown=root:root php.ini /usr/local/etc/php/php.ini
 
 RUN apt-get -qy update &&\
     apt-get -qy install --no-install-recommends git libc6 libcurl4-openssl-dev libfuzzy-dev libfreetype-dev libgd3 \
-    libicu-dev libjpeg-dev libgpgme-dev libpng-dev librdkafka-dev libwebp-dev libzip-dev &&\
+    libicu-dev libjpeg-dev libgpgme-dev libonig-dev libpng-dev librdkafka-dev libwebp-dev libzip-dev &&\
     docker-php-ext-install bcmath curl gd intl json mysqli opcache pcntl pdo_mysql zip
 RUN pecl install apcu &&\
     pecl install gnupg &&\
@@ -28,8 +28,8 @@ RUN git clone -q --recursive --depth=1 https://github.com/kjdev/php-ext-brotli.g
     ./configure &&\
     make install
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp &&\
-    docker-php-ext-install gd gettext sockets &&\
-    docker-php-ext-enable apcu brotli gd gettext gnupg mongodb rdkafka redis simdjson sockets ssdeep
+    docker-php-ext-install exif gd gettext mbstring sockets &&\
+    docker-php-ext-enable apcu brotli exif gd gettext gnupg mbstring mongodb rdkafka redis simdjson sockets ssdeep
 
 # Build Python 3.10
 FROM debian:bullseye AS python_build

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -80,7 +80,7 @@ setup_smtp() {
 restore_persistence() {
     echo "Restoring persistent file storage..."
     cd /var/www/ || exit 1
-    mkdir -p MISPData/attachments MISPData/config MISPData/custom_scripts MISPData/files MISPData/images MISPData/tmp
+    mkdir -p MISPData/attachments MISPData/config MISPData/custom_scripts MISPData/files MISPData/files/img/orgs MISPData/images MISPData/tmp
 
     if [ ! -L MISP/app/Config ]; then
         echo "Persisting config..."
@@ -139,7 +139,7 @@ restore_persistence() {
     # Migrate organisation icons from pre v2.4.185
     if [ -d MISPData/icons/ ]; then
         if [ ! -z "$(ls -A MISPData/icons/)" ]; then
-            # If MISPData/icons is not empty 
+            # If MISPData/icons is not empty
             echo "Relocating org icons..."
             mv MISPData/icons/* MISPData/files/img/orgs/
         fi

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -135,20 +135,11 @@ restore_persistence() {
     chmod 644 MISPData/tmp/logs/*
     chown -R www-data: MISPData/tmp/logs
 
-    if [ ! -L MISP/app/webroot/img/orgs ]; then
-        echo "Persisting org icons..."
-        if [ ! -f /var/www/MISPData/.configured ]; then
-            if [ "$(ls -A MISPData/icons/)" ]; then
-                echo "MISP isn't configured but files exist - assuming files are valid"
-                echo "If MISP does not run properly clear MISPData mountpoint and create misp-web container"
-            else
-                mv MISP/app/webroot/img/orgs/* MISPData/icons/
-            fi
-        fi
-        rm -rf MISP/app/webroot/img/orgs
-        ln -s /var/www/MISPData/icons/ /var/www/MISP/app/webroot/img/orgs
-    else
-        echo "Org icons already persistent."
+    # Migrate organisation icons from pre v2.4.185
+    if [ -d MISPData/icons/ ]; then
+        echo "Relocating org icons..."
+        mv MISPData/icons/* MISPData/files/img/orgs/
+        rm -rf MISPData/icons/
     fi
 
     if [ ! -L MISP/app/webroot/img/custom ]; then

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -80,7 +80,7 @@ setup_smtp() {
 restore_persistence() {
     echo "Restoring persistent file storage..."
     cd /var/www/ || exit 1
-    mkdir -p MISPData/attachments MISPData/config MISPData/custom_scripts MISPData/files MISPData/files/img/orgs MISPData/images MISPData/tmp
+    mkdir -p MISPData/attachments MISPData/config MISPData/custom_scripts MISPData/files MISPData/images MISPData/tmp
 
     if [ ! -L MISP/app/Config ]; then
         echo "Persisting config..."
@@ -141,6 +141,7 @@ restore_persistence() {
         if [ ! -z "$(ls -A MISPData/icons/)" ]; then
             # If MISPData/icons is not empty
             echo "Relocating org icons..."
+            mkdir -p MISPData/files/img/orgs
             mv MISPData/icons/* MISPData/files/img/orgs/
         fi
         rm -rf MISPData/icons/

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2023 Jisc Services Limited
 # SPDX-FileContributor: Joe Pitt
 # SPDX-FileContributor: James Acris - OIDC Support
+# SPDX-FileContributor: James Ellor
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
@@ -79,7 +80,7 @@ setup_smtp() {
 restore_persistence() {
     echo "Restoring persistent file storage..."
     cd /var/www/ || exit 1
-    mkdir -p MISPData/attachments MISPData/config MISPData/custom_scripts MISPData/files MISPData/icons MISPData/images MISPData/tmp
+    mkdir -p MISPData/attachments MISPData/config MISPData/custom_scripts MISPData/files MISPData/images MISPData/tmp
 
     if [ ! -L MISP/app/Config ]; then
         echo "Persisting config..."
@@ -137,8 +138,11 @@ restore_persistence() {
 
     # Migrate organisation icons from pre v2.4.185
     if [ -d MISPData/icons/ ]; then
-        echo "Relocating org icons..."
-        mv MISPData/icons/* MISPData/files/img/orgs/
+        if [ ! -z "$(ls -A MISPData/icons/)" ]; then
+            # If MISPData/icons is not empty 
+            echo "Relocating org icons..."
+            mv MISPData/icons/* MISPData/files/img/orgs/
+        fi
         rm -rf MISPData/icons/
     fi
 


### PR DESCRIPTION
# Description

In v2.4.185, MISP relocated the org icons directory, which was being remapped by this project, this PR resolves this conflict and adds some missing dependencies for adding org icons via the web UI.

There is a known issue in v2.4.185 which SVG are not displayed, this is due to an incorrectly hard coded mime type in MISP, so outside our control.

## Related Issue(s)

(none)

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.
- [x] Existing icons still display post upgrade.
- [x] New icons can be uploaded.

**Test Configuration**:
* Docker Host OS: Rocky Linux release 9.3
* Docker Engine Version: 25.0.3
* MISP Version: v2.4.185

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
