### PR TITLE
fix: auth key leading spaces

### DIFF
--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -21,7 +21,8 @@ RUN pecl install apcu &&\
     pecl install simdjson &&\
     ln -s /usr/lib/x86_64-linux-gnu/libfuzzy.so /usr/lib/libfuzzy.so &&\
     ldconfig &&\
-    pecl install ssdeep
+    pecl install ssdeep &&\
+    pecl install zstd
 RUN git clone -q --recursive --depth=1 https://github.com/kjdev/php-ext-brotli.git &&\
     cd php-ext-brotli &&\
     phpize &&\
@@ -29,7 +30,7 @@ RUN git clone -q --recursive --depth=1 https://github.com/kjdev/php-ext-brotli.g
     make install
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp &&\
     docker-php-ext-install exif gd gettext mbstring sockets &&\
-    docker-php-ext-enable apcu brotli exif gd gettext gnupg mbstring mongodb rdkafka redis simdjson sockets ssdeep
+    docker-php-ext-enable apcu brotli exif gd gettext gnupg mbstring mongodb rdkafka redis simdjson sockets ssdeep zstd
 
 # Build Python 3.10
 FROM debian:bullseye AS python_build

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -220,7 +220,7 @@ initial_config() {
     echo 'Setting "Security.salt" changed to "[REDACTED]"'
     $CAKE userInit -q >/dev/null 2>&1
     $CAKE Admin setSetting "Security.advanced_authkeys" false
-    python3 /opt/scripts/set_auth_key.py -k "$($CAKE Admin getAuthKey admin@admin.test 2>&1)" >/dev/null 2>&1
+    python3 /opt/scripts/set_auth_key.py -k "$($CAKE Admin getAuthKey admin@admin.test | tr -d "[:blank:]" 2>&1)" >/dev/null 2>&1
     $CAKE Admin setSetting "MISP.baseurl" "$MISP_URL"
     $CAKE Admin setSetting "MISP.external_baseurl" "$MISP_URL"
     $CAKE Admin setSetting "MISP.uuid" "$(uuid -v 4)"

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -138,7 +138,7 @@ restore_persistence() {
 
     # Migrate organisation icons from pre v2.4.185
     if [ -d MISPData/icons/ ]; then
-        if [ ! -z "$(ls -A MISPData/icons/)" ]; then
+        if [ -n "$(ls -A MISPData/icons/)" ]; then
             # If MISPData/icons is not empty
             echo "Relocating org icons..."
             mkdir -p MISPData/files/img/orgs


### PR DESCRIPTION
# Description

CakePHP has started prefixing its output with four spaces, breaking the initial setup, `tr` has been added to strip all leading and trailing whitespace to prevent the issue.

Also added new recommended PHP module `zstd` for better compression during server sync.

Double negative test replaced in web entrypoint.

## Related Issue(s)

* (none)

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.

**Test Configuration**:
* Docker Host OS: Rocky Linux 9.3
* Docker Engine Version: 26.0.0
* MISP Version: 2.4.188

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
