### PR TITLE
feat: run GitHub Actions on PRs

### DIFF
--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -16,7 +16,21 @@ jobs:
   run-dev:
     name: Build, Test, and Release (Dev)
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: 'write'
     steps:
+      - id: pr-comment-start
+        name: Add Comment to PR (Start)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Test images for this PR are now being built, see Actions tab for details.'
+            })
       # Environment Setup
       - id: checkout
         name: Checkout Project
@@ -139,8 +153,8 @@ jobs:
         if: steps.build_shibb.outcome == 'success'
         run: |
           docker image push ${{ vars.DOCKERHUB_ORGANISATION }}/misp-shibb-sp:${{ env.BRANCH_NAME }}
-      - id: pr-comment
-        name: Add Comment to PR
+      - id: pr-comment-done
+        name: Add Comment to PR (Done)
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -61,6 +61,15 @@ jobs:
         name: Get current Shibboleth SP version number
         run: echo "SHIBB_VERSION=$(python3 ./misp-shibb-sp/latest.py)" >> $GITHUB_ENV
 
+      # Print Image tag and upstream version
+      - id: print_versions
+        name: Image Tag and Upstream Versions
+        run: |
+          echo "- ${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ env.BRANCH_NAME }} using upstream version ${{ env.MODULES_VERSION }}"
+          echo "- ${{ vars.DOCKERHUB_ORGANISATION }}/misp-shibb-sp:${{ env.BRANCH_NAME }} using upstream version v${{ env.SHIBB_VERSION }}"
+          echo "- ${{ vars.DOCKERHUB_ORGANISATION }}/misp-web:${{ env.BRANCH_NAME }} using upstream version ${{ env.MISP_VERSION }}"
+          echo "- ${{ vars.DOCKERHUB_ORGANISATION }}/misp-workers:${{ env.BRANCH_NAME }} using upstream version ${{ env.MISP_VERSION }}"
+      
       # Build / Pull Images
       - id: build_modules
         name: Build misp-modules

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   COMPOSE_PROJECT_NAME: misp_dev
-  BRANCH_NAME: ${{ github.event.pull_request.id || github.head_ref || github.ref_name }} 
+  BRANCH_NAME: ${{ github.event.pull_request.number || github.head_ref || github.ref_name }} 
 jobs:
   run-dev:
     name: Build, Test, and Release (Dev)

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -139,3 +139,15 @@ jobs:
         if: steps.build_shibb.outcome == 'success'
         run: |
           docker image push ${{ vars.DOCKERHUB_ORGANISATION }}/misp-shibb-sp:${{ env.BRANCH_NAME }}
+      - id: pr-comment
+        name: Add Comment to PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'New test images for this PR have been published: `${{ vars.DOCKERHUB_ORGANISATION }}/misp-modules:${{ env.BRANCH_NAME }}` `${{ vars.DOCKERHUB_ORGANISATION }}/misp-web:${{ env.BRANCH_NAME }}` `${{ vars.DOCKERHUB_ORGANISATION }}/misp-workers:${{ env.BRANCH_NAME }}` `${{ vars.DOCKERHUB_ORGANISATION }}/misp-shibb-sp:${{ env.BRANCH_NAME }}`'
+            })

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -142,7 +142,7 @@ jobs:
       - id: pr-comment
         name: Add Comment to PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -11,9 +11,11 @@ on:
       - '**'
       - '!main'
   workflow_dispatch:
+  pull_request:
+
 env:
   COMPOSE_PROJECT_NAME: misp_dev
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+  BRANCH_NAME: ${{ github.event.pull_request.id || github.head_ref || github.ref_name }} 
 jobs:
   run-dev:
     name: Build, Test, and Release (Dev)

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -6,10 +6,6 @@
 
 name: Development Images
 on:
-  push:
-    branches:
-      - '**'
-      - '!main'
   workflow_dispatch:
   pull_request:
 


### PR DESCRIPTION
# Description

PRs raised by third parties cannot be merged as GitHub Actions do not run currently, this PR makes dev images run for future PRs.

External contributors will need approval to trigger PR actions (see: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)

## Related Issue(s)

* #16  - cannot be merged automatically until implemented.

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [ ] Manual deployment and testing of MISP successful. - N/A

**Test Configuration**:
* Docker Host OS: N/A
* Docker Engine Version: N/A
* MISP Version: N/A

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
