### PR TITLE
MISP 2.5 / PHP 8.2

### DIFF
--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 # Build PHP Modules
-FROM php:7.4-apache AS php_build
+FROM php:8.3-apache AS php_build
 ARG DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 
 COPY --chown=root:root php.ini /usr/local/etc/php/php.ini
@@ -12,17 +12,18 @@ COPY --chown=root:root php.ini /usr/local/etc/php/php.ini
 RUN apt-get -qy update &&\
     apt-get -qy install --no-install-recommends git libc6 libcurl4-openssl-dev libfuzzy-dev libfreetype-dev libgd3 \
     libicu-dev libjpeg-dev libgpgme-dev libonig-dev libpng-dev librdkafka-dev libwebp-dev libzip-dev &&\
-    docker-php-ext-install bcmath curl gd intl json mysqli opcache pcntl pdo_mysql zip
+    docker-php-ext-install bcmath curl gd intl mysqli opcache pcntl pdo_mysql zip
 RUN pecl install apcu &&\
     pecl install gnupg &&\
     pecl install mongodb &&\
     pecl install rdkafka &&\
     pecl install redis &&\
     pecl install simdjson &&\
-    ln -s /usr/lib/x86_64-linux-gnu/libfuzzy.so /usr/lib/libfuzzy.so &&\
-    ldconfig &&\
-    pecl install ssdeep &&\
     pecl install zstd
+RUN ln -s /usr/lib/x86_64-linux-gnu/libfuzzy.so /usr/lib/libfuzzy.so &&\
+    ldconfig &&\
+    git clone --recursive --depth=1 https://github.com/JakubOnderka/pecl-text-ssdeep.git /tmp/pecl-text-ssdeep &&\
+    cd /tmp/pecl-text-ssdeep && phpize && ./configure && make && make install
 RUN git clone -q --recursive --depth=1 https://github.com/kjdev/php-ext-brotli.git &&\
     cd php-ext-brotli &&\
     phpize &&\
@@ -32,30 +33,15 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp &&\
     docker-php-ext-install exif gd gettext mbstring sockets &&\
     docker-php-ext-enable apcu brotli exif gd gettext gnupg mbstring mongodb rdkafka redis simdjson sockets ssdeep zstd
 
-# Build Python 3.10
-FROM debian:bullseye AS python_build
-RUN apt-get -yq update &&\
-    apt-get -yq install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev\
-    libffi-dev libsqlite3-dev wget libbz2-dev
-WORKDIR /opt/
-RUN wget --progress=dot:giga https://www.python.org/ftp/python/3.12.5/Python-3.12.5.tgz &&\
-    tar xfz Python-3.12.5.tgz
-WORKDIR /opt/Python-3.12.5
-RUN ./configure --prefix=/usr/local --enable-optimizations &&\
-    make &&\
-    make install
-RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools
-
 # Build MISP
-FROM php:7.4-apache AS misp_build
+FROM php:8.3-apache AS misp_build
 ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 
 # Install build dependencies
 RUN apt-get -qy update &&\
     apt-get -qy install --no-install-recommends cmake gcc git libcaca-dev libfuzzy-dev libgpgme11 libjpeg-dev liblua5.3-dev\
     libopencv-dev libpoppler-cpp-dev librdkafka-dev libxml2-dev libxslt1-dev libyara-dev libzbar-dev libzip4 make\
-    openssl\
-    ruby sqlite3 ssdeep tesseract-ocr unzip zip zlib1g-dev
+    openssl python3 python3-dev python3-venv ruby sqlite3 ssdeep tesseract-ocr unzip zip zlib1g-dev
 
 # Download MISP
 WORKDIR /var/www/
@@ -67,34 +53,35 @@ RUN git config --global advice.detachedHead false &&\
     git submodule foreach --recursive git config core.filemode false &&\
     git config core.filemode false
 
-COPY --from=php_build --chown=root:root /usr/local/lib/php/extensions/no-debug-non-zts-20190902/ \
-    /usr/local/lib/php/extensions/no-debug-non-zts-20190902/
+COPY --from=php_build --chown=root:root /usr/local/lib/php/extensions/no-debug-non-zts-20230831/ \
+    /usr/local/lib/php/extensions/no-debug-non-zts-20230831/
 COPY --from=php_build --chown=root:root /usr/local/etc/php/ /usr/local/etc/php/
-COPY --from=python_build /usr/local /usr/local
 
 WORKDIR /var/www/MISP/app
 ARG COMPOSER_ALLOW_SUPERUSER=1
 RUN php composer.phar -q self-update &&\
     php composer.phar -q config --no-plugins allow-plugins.composer/installers true &&\
     php composer.phar -q config --no-plugins allow-plugins.php-http/discovery true &&\
-    php composer.phar -q install --no-dev &&\
-    php composer.phar suggests --all | sed -nr 's/- (.+\/.+):/\1/p' | awk '{print $1}' | sort | uniq \
-        | xargs -I {} php composer.phar -q require --with-all-dependencies {}
+    php composer.phar -q install &&\
+    php composer.phar -q require --with-all-dependencies elasticsearch/elasticsearch &&\
+    php composer.phar -q require --with-all-dependencies aws/aws-sdk-php &&\
+    php composer.phar -q require --with-all-dependencies jakub-onderka/openid-connect-php
 WORKDIR /var/www/MISP
 RUN cp -fa INSTALL/setup/config.php app/Plugin/CakeResque/Config/config.php &&\
     python3 -m venv venv &&\
-    ./venv/bin/pip -q install --no-cache-dir --upgrade pip setuptools &&\
-    ./venv/bin/pip -q install --no-cache-dir ordered-set python-dateutil six weakrefmethod &&\
-    ./venv/bin/pip -q install --no-cache-dir ./app/files/scripts/misp-stix &&\
-    ./venv/bin/pip -q install --no-cache-dir ./PyMISP &&\
-    ./venv/bin/pip -q install --no-cache-dir git+https://github.com/kbandla/pydeep.git &&\
-    ./venv/bin/pip -q install --no-cache-dir lief &&\
-    ./venv/bin/pip -q install --no-cache-dir zmq redis &&\
-    ./venv/bin/pip -q install --no-cache-dir python-magic &&\
-    ./venv/bin/pip -q install --no-cache-dir plyara yara &&\
+    . ./venv/bin/activate &&\
+    pip -q install --no-cache-dir --upgrade pip setuptools &&\
+    pip -q install --no-cache-dir ordered-set python-dateutil six weakrefmethod &&\
+    pip -q install --no-cache-dir ./app/files/scripts/misp-stix &&\
+    pip -q install --no-cache-dir ./PyMISP &&\
+    pip -q install --no-cache-dir git+https://github.com/kbandla/pydeep.git &&\
+    pip -q install --no-cache-dir lief &&\
+    pip -q install --no-cache-dir zmq redis &&\
+    pip -q install --no-cache-dir python-magic &&\
+    pip -q install --no-cache-dir plyara yara &&\
     cd PyMISP &&\
     git submodule foreach "git pull -q origin main || git pull -q origin master || exit 0" &&\
-    /var/www/MISP/venv/bin/pip -q install --no-cache-dir /var/www/MISP/PyMISP/.[fileobjects,openioc,virustotal,pdfexport]
+    pip -q install --no-cache-dir /var/www/MISP/PyMISP/.[fileobjects,openioc,virustotal,pdfexport]
 WORKDIR /var/www
 RUN find /var/www -type d -name .git -exec rm -r {} + &&\
     mkdir MISP/.git &&\
@@ -108,7 +95,7 @@ RUN find /var/www -type d -name .git -exec rm -r {} + &&\
     rm -rf misp-decaying-models misp-galaxy misp-objects misp-workflow-blueprints noticelists taxonomies warninglists
 
 # Build final image
-FROM php:7.4-apache AS final
+FROM php:8.3-apache AS final
 ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 ENV AUTH_METHOD=misp CLAMAV_HOSTNAME=misp_clamav FQDN=misp.local GPG_PASSPHRASE=misp \
     HTTPS_PORT=443 MISP_EMAIL_ADDRESS=misp@misp.local MISP_EMAIL_NAME=MISP \
@@ -124,7 +111,7 @@ LABEL org.opencontainers.image.title="misp-web" org.opencontainers.image.version
     org.opencontainers.image.ref.name="misp-web" \
     org.opencontainers.image.description="Open Source Threat Intelligence and Sharing Platform." \
     org.opencontainers.image.authors="Jisc <CTI.Analysts@jisc.ac.uk" \
-    org.opencontainers.image.base.name="hub.docker.com/_/php:7.4-apache"
+    org.opencontainers.image.base.name="hub.docker.com/_/php:8.3-apache"
 VOLUME "/etc/ssl/private/" "/var/www/MISPData" "/var/www/MISPGnuPG"
 EXPOSE 80 443
 
@@ -134,13 +121,12 @@ ENV CAKE="sudo -H -u www-data /var/www/MISP/app/Console/cake"
 RUN apt-get -qy update &&\
     apt-get -qy upgrade apache2 &&\
     apt-get -qy install --no-install-recommends git gnupg iputils-ping libapache2-mod-shib\
-        libfuzzy2 libgd3 libgpgme11 libpng16-16 librdkafka1 libzip4 mariadb-client ssdeep sudo uuid\
-        zip &&\
+        libfuzzy2 libgd3 libgpgme11 libpng16-16 librdkafka1 libzip4 mariadb-client python3\
+        python3-venv ssdeep sudo uuid zip &&\
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=php_build --chown=root:root /usr/local/lib/php/extensions/no-debug-non-zts-20190902/ /usr/local/lib/php/extensions/no-debug-non-zts-20190902/
+COPY --from=php_build --chown=root:root /usr/local/lib/php/extensions/no-debug-non-zts-20230831/ /usr/local/lib/php/extensions/no-debug-non-zts-20230831/
 COPY --from=php_build --chown=root:root /usr/local/etc/php/ /usr/local/etc/php/
-COPY --from=python_build /usr/local /usr/local
 COPY --from=misp_build --chown=www-data:www-data /var/www/ /var/www
 COPY --chown=root:root apache.* /etc/apache2/sites-available/
 COPY --chown=root:root scripts/ /opt/scripts

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -346,7 +346,7 @@ on_start() {
     $CAKE Admin setSetting "MISP.baseurl" "$MISP_URL"
     $CAKE Admin setSetting "MISP.external_baseurl" "$MISP_URL"
     $CAKE Admin setSetting "MISP.org" "$ORG_NAME"
-    /usr/local/bin/python3 /opt/scripts/trigger_set_org_name.py
+    python3 /opt/scripts/trigger_set_org_name.py
     $CAKE Admin setSetting "Security.otp_required" "$REQUIRE_TOTP"
 
     sed -i "s/^\(session.save_handler\).*/\1 = redis/" /usr/local/etc/php/php.ini

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -240,6 +240,7 @@ initial_config() {
     echo 'Setting "Security.encryption_key" changed to "[REDACTED]"'
     $CAKE Admin setSetting "MISP.email_from_name" "$MISP_EMAIL_NAME"
     $CAKE Admin setSetting "Plugin.Enrichment_clamav_connection" "${CLAMAV_HOSTNAME}:3310"
+    $CAKE Admin setSetting "MISP.email_reply_to" "$MISP_EMAIL_ADDRESS"
     echo "Setting $(grep --count CAKE /opt/scripts/misp-post-update-config.sh) post upgrade configuration settings..."
     /opt/scripts/misp-post-update-config.sh >/dev/null
     echo "Post upgrade configuration complete."

--- a/misp-web/scripts/misp-base-config.sh
+++ b/misp-web/scripts/misp-base-config.sh
@@ -260,4 +260,4 @@ $CAKE Admin setSetting "MISP.default_publish_alert" false
 $CAKE Admin setSetting "MISP.welcome_text_top" "" --force
 $CAKE Admin setSetting "MISP.welcome_text_bottom" "" --force
 $CAKE Admin setSetting "MISP.footermidleft" "" --force
-$CAKE Admin setSetting "MISP.footermidright" "" --force
+$CAKE Admin setSetting "MISP.footermidright" "and hub.docker.com/r/jisccti/misp-web"

--- a/misp-web/scripts/misp-base-config.sh
+++ b/misp-web/scripts/misp-base-config.sh
@@ -198,7 +198,6 @@ $CAKE Admin setSetting "Plugin.Enrichment_hover_enable" true
 $CAKE Admin setSetting "Plugin.Enrichment_hover_popover_only" false
 $CAKE Admin setSetting "Plugin.Enrichment_hover_timeout" 150
 $CAKE Admin setSetting "Plugin.Enrichment_timeout" 300
-$CAKE Admin setSetting "Plugin.Enrichment_bgpranking_enabled" true
 $CAKE Admin setSetting "Plugin.Enrichment_countrycode_enabled" true
 $CAKE Admin setSetting "Plugin.Enrichment_cve_enabled" true
 $CAKE Admin setSetting "Plugin.Enrichment_cve_advanced_enabled" true

--- a/misp-web/scripts/misp-post-update-config.sh
+++ b/misp-web/scripts/misp-post-update-config.sh
@@ -15,3 +15,4 @@ $CAKE Admin setSetting "MISP.self_update" false
 $CAKE Admin setSetting "MISP.store_api_access_time" true
 $CAKE Admin setSetting "MISP.thumbnail_in_redis" true
 $CAKE Admin setSetting "MISP.unpublishedprivate" false
+$CAKE Admin setSetting "Security.alert_on_suspicious_logins" true

--- a/misp-web/scripts/misp_maintenance_jobs.ini
+++ b/misp-web/scripts/misp_maintenance_jobs.ini
@@ -10,7 +10,7 @@ debug = False
 verifytls = False
 
 [rotate_logs]
-command = /usr/local/bin/python3 /opt/scripts/rotate_logs.py
+command = /var/www/MISP/venv/bin/python3 /opt/scripts/rotate_logs.py
 enabled = True
 interval = 60
 lastrun = 0

--- a/misp-workers/Dockerfile
+++ b/misp-workers/Dockerfile
@@ -5,7 +5,7 @@
 
 ARG MISP_VERSION=0.0.0
 FROM jisccti/misp-web:${MISP_VERSION} AS web
-FROM php:7.4-cli AS final
+FROM php:8.3-cli AS final
 ARG MISP_VERSION=0.0.0
 ENV FQDN=misp.local HTTPS_PORT=443 ORG_NAME=ORGNAME ORG_UUID=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX \
     WORKERS_PASSWORD=misp
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.title="misp-workers" \
     org.opencontainers.image.ref.name="misp-workers" \
     org.opencontainers.image.description="Open Source Threat Intelligence and Sharing Platform." \
     org.opencontainers.image.authors="Jisc <CTI.Analysts@jisc.ac.uk" \
-    org.opencontainers.image.base.name="hub.docker.com/_/php:7.4-cli"
+    org.opencontainers.image.base.name="hub.docker.com/_/php:8.3-cli"
 ENV CAKE="sudo -H -u www-data /var/www/MISP/app/Console/cake"
 EXPOSE 9001
 VOLUME "/var/www/MISPData" "/var/www/MISPGnuPG"


### PR DESCRIPTION
# Description

Migrate to PHP 8.2 following the release of MISP 2.5.0.

Also add additional base configuration, including enabling `alert_on_suspicious_logins` by default.

## Related Issue(s)

* (none)

## Type of change

Please tick options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.
- [x] Upgrade of v2.4.198 instances successful.

**Test Configuration**:
* Docker Host OS: Rocky Linux 9.4
* Docker Engine Version: 27.3.1
* MISP Version: 2.5.0

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
