### PR TITLE
Migrate Modules to Debian Bookworm

### DIFF
--- a/misp-modules/Dockerfile
+++ b/misp-modules/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-FROM python:3.12-slim-bullseye AS build
+FROM python:3.12-slim-bookworm AS build
 ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 RUN apt-get update -yq &&\
     apt-get install -yq g++ git libpoppler-cpp-dev &&\
@@ -21,7 +21,7 @@ RUN apt-get update -yq &&\
     sed -i "s|print \"Could not find 'content.xml': {}\".format(str(e))|print(\"Could not find 'content.xml': {}\".format(str(e)))|" /misp_modules/lib/python3.12/site-packages/ODTReader/odtreader.py &&\
     sed -i "s|print output|print(output)|" /misp_modules/lib/python3.12/site-packages/ODTReader/odtreader.py
 
-FROM python:3.12-slim-bullseye AS final
+FROM python:3.12-slim-bookworm AS final
 ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical REDIS_BACKEND=misp_redis REDIS_DATABASE=1
 LABEL org.opencontainers.image.title="misp-modules" org.opencontainers.image.version=${MISP_VERSION}\
     org.opencontainers.image.ref.name="misp-modules"\


### PR DESCRIPTION
# Description

Migrate `misp-modules` to Debian Bookworm addressing one high severity vulnerability in the base image.

## Related Issue(s)

* (none)

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.

**Test Configuration**:
* Docker Host OS: Rocky Linux 9.4
* Docker Engine Version: 27.3.1
* MISP Version: 2.5.0

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
