### PR TITLE
fix: add publicsuffixlist python modules to misp-modules Dockerfile

### DIFF
--- a/misp-modules/Dockerfile
+++ b/misp-modules/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -yq &&\
         misp-modules==${MISP_VERSION}\
         ODTReader\
         pip\
+        publicsuffixlist \
         setuptools\
         trustar\
         git+https://github.com/abenassi/Google-Search-API\


### PR DESCRIPTION
# Description

The misp-modules Dockerfile does not have the Python package "publicsuffixlist", which results in some modules not being loaded

## Related Issue(s)

No related issue

## Type of change

Please tick options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Built the container and the warning about the missing package during initialization went away. The modules that previously failed were now being instantiated correctly.

- [ ] GitHub Actions Development Images passing.
- [X] Manual deployment and testing of MISP successful.
- [ ] ... change specific tests here ...

**Test Configuration**:
* Docker Host OS: Ubuntu 22.04
* Docker Engine Version: 27.4.0, build bde2b89
* MISP Version: 2.5.9
* MISP Modules Version: 2.4.201

# Checklist:

- [X] I have performed a self-review of my code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
