### PR TITLE
feat: upgrade misp-modules to v3.x

### DIFF
--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -43,6 +43,8 @@ services:
     hostname: ${MODULES_HOSTNAME:-misp_modules}
     image: jisccti/misp-modules:latest
     restart: unless-stopped
+    volumes:
+      - ./persistent/${COMPOSE_PROJECT_NAME}/modules_cache/:/mnt/cache
   redis:
     entrypoint: redis-server --loglevel warning --requirepass ${REDIS_PASSWORD:-misp}
     environment:

--- a/docker-compose-shibb.yml
+++ b/docker-compose-shibb.yml
@@ -43,6 +43,8 @@ services:
     hostname: ${MODULES_HOSTNAME:-misp_modules}
     image: jisccti/misp-modules:latest
     restart: unless-stopped
+    volumes:
+      - ./persistent/${COMPOSE_PROJECT_NAME}/modules_cache/:/mnt/cache
   redis:
     entrypoint: redis-server --loglevel warning --requirepass ${REDIS_PASSWORD:-misp}
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     hostname: ${MODULES_HOSTNAME:-misp_modules}
     image: jisccti/misp-modules:latest
     restart: unless-stopped
+    volumes:
+      - ./persistent/${COMPOSE_PROJECT_NAME}/modules_cache/:/mnt/cache
   redis:
     entrypoint: redis-server --loglevel warning --requirepass ${REDIS_PASSWORD:-misp}
     environment:

--- a/misp-modules/Dockerfile
+++ b/misp-modules/Dockerfile
@@ -1,40 +1,35 @@
-# SPDX-FileCopyrightText: 2023-2024 Jisc Services Limited
+# SPDX-FileCopyrightText: 2023-2025 Jisc Services Limited
 # SPDX-FileContributor: Joe Pitt
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
 FROM python:3.12-slim-bookworm AS build
 ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
-RUN apt-get update -yq &&\
-    apt-get install -yq g++ git libpoppler-cpp-dev &&\
-    python3 -m venv /misp_modules &&\
-    . /misp_modules/bin/activate &&\
-    python3 -m pip install --upgrade  --no-cache-dir --quiet \
-        misp-modules==${MISP_VERSION}\
-        ODTReader\
-        pip\
-        setuptools\
-        trustar\
-        git+https://github.com/abenassi/Google-Search-API\
-        git+https://github.com/onyphe/pyonyphe\
-        git+https://github.com/sebdraven/pydnstrails.git &&\
-    sed -i "s|print \"Could not find 'content.xml': {}\".format(str(e))|print(\"Could not find 'content.xml': {}\".format(str(e)))|" /misp_modules/lib/python3.12/site-packages/ODTReader/odtreader.py &&\
-    sed -i "s|print output|print(output)|" /misp_modules/lib/python3.12/site-packages/ODTReader/odtreader.py
+RUN apt-get update -yq && apt-get install -yq g++ git libzbar0 libpoppler-cpp-dev tesseract-ocr
+RUN python3 -m venv /misp_modules
+RUN . /misp_modules/bin/activate &&\
+    python3 -m pip install --upgrade  --no-cache-dir --quiet misp-modules[all]==${MISP_VERSION}
 
 FROM python:3.12-slim-bookworm AS final
-ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical REDIS_BACKEND=misp_redis REDIS_DATABASE=1
-LABEL org.opencontainers.image.title="misp-modules" org.opencontainers.image.version=${MISP_VERSION}\
+ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical \
+    REDIS_BACKEND=misp_redis REDIS_DATABASE=1
+LABEL org.opencontainers.image.title="misp-modules" \
+    org.opencontainers.image.version=${MISP_VERSION}\
     org.opencontainers.image.ref.name="misp-modules"\
     org.opencontainers.image.description="Modules for expansion services, import and export in MISP."\
     org.opencontainers.image.authors="Jisc <CTI.Analysts@jisc.ac.uk"\
     org.opencontainers.image.base.name="hub.docker.com/_/python:3.12-slim-bullseye"
+ENV HOME=/mnt/cache/ MPLCONFIGDIR=/mnt/cache/matplotlib
 EXPOSE 6666
 
 RUN apt-get update &&\
-    apt-get install -y curl libglib2.0-0 libpoppler-cpp0v5 libzbar0 libgl1 &&\
+    apt-get install -y curl libglib2.0-0 libpoppler-cpp0v5 libzbar0 libgl1 tesseract-ocr &&\
     rm -rf /var/lib/apt/lists/* &&\
-    python3 -m pip install --upgrade pip setuptools --no-cache-dir
+    python3 -m pip install --upgrade pip setuptools --no-cache-dir &&\
+    mkdir -p /mnt/cache/matplotlib &&\
+    chown -R nobody:nogroup /mnt/cache
 
+VOLUME [ "/mnt/cache/" ]
 COPY --from=build /misp_modules/ /misp_modules/
 WORKDIR /misp_modules/bin/
 ENTRYPOINT ["./misp-modules", "-l", "0.0.0.0"]

--- a/misp-modules/latest.py
+++ b/misp-modules/latest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2023-2024 Jisc Services Limited
+# SPDX-FileCopyrightText: 2023-2025 Jisc Services Limited
 # SPDX-FileContributor: Joe Pitt
 #
 # SPDX-License-Identifier: GPL-3.0-only
@@ -25,4 +25,4 @@ __maintainer__ = "Joe Pitt"
 __status__ = "Production"
 __version__ = "1.0.1"
 
-print(get_latest_from_github_tags("MISP/misp-modules", 2))
+print(get_latest_from_github_tags("MISP/misp-modules", 3))

--- a/pages/dev/misp-modules.md
+++ b/pages/dev/misp-modules.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 Jisc Services Limited
+SPDX-FileCopyrightText: 2024-2025 Jisc Services Limited
 SPDX-FileContributor: Joe Pitt
 SPDX-FileContributor: James Ellor
 
@@ -31,4 +31,8 @@ The image exposes 6666/tcp - the modules web interface.
 
 ## Volumes
 
-The image has no volumes.
+The image uses the following volume:
+
+| Mount Point | Purpose |
+|-------------|---------|
+| /mnt/cache/ | Cache directories for `Fontconfig` and `matplotlib`. |


### PR DESCRIPTION
# Description

Upgrades MISP Modules to version 3.x and install all dependencies via the Provides-Extra: all install option.

Added `/mnt/cache` volume for `Fontconfig` and `matplotlib`, resolving warnings during container start up.

## Related Issue(s)

* Report of missing dependencies from @chodonne
* Report of errors loading workflows page.

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.

**Test Configuration**:
* Docker Host OS: Rocky Linux 9.5
* Docker Engine Version: 28.1.1
* MISP Version:  2.5.9

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
