### PR TITLE
ACME webroot-path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - ${HTTPS_PORT:-443}:443
     restart: unless-stopped
     volumes:
+      #- /etc/letsencrypt/live/MISP:/etc/letsencrypt/live/MISP:ro
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG
@@ -126,7 +127,6 @@ services:
     image: jisccti/misp-workers:latest
     restart: unless-stopped
     volumes:
-      #- /etc/letsencrypt/live/MISP:/etc/letsencrypt/live/MISP:ro
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG

--- a/pages/configuration/general.md
+++ b/pages/configuration/general.md
@@ -94,7 +94,7 @@ your chosen CA's documentation for how to use other challenge types such as DNS-
 
 ```sh
 certbot certonly --non-interactive --agree-tos --email certmaster@org.ac.uk \
-    --webroot --webroot-path /opt/misp/persistent/misp/acme \
+    --webroot --webroot-path /opt/misp/persistent/misp/data/acme \
     --cert-name MISP --domain misp.org.ac.uk \
     --deploy-hook '/usr/bin/docker container restart $(docker ps --filter ancestor=jisccti/misp-web:latest -aq)'
 ```


### PR DESCRIPTION
# Description

Correct two typos related to ACME managed certificates.

## Related Issue(s)

* `--webroot-path` incorrect in documentation - reported by Shawn McKee at the University of Michigan.
* Example ACME volume mount on wrong service.

## Type of change

Please tick options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

n/a documentation changes only

**Test Configuration**:
* Docker Host OS: n/a
* Docker Engine Version: n/a
* MISP Version: n/a

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
