### PR TITLE
fix: add volume for certbot archive directory

### DIFF
--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -115,6 +115,7 @@ services:
     image: jisccti/misp-web:latest
     restart: unless-stopped
     volumes:
+      #- /etc/letsencrypt/archive/MISP:/etc/letsencrypt/archive/MISP:ro
       #- /etc/letsencrypt/live/MISP:/etc/letsencrypt/live/MISP:ro
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData

--- a/docker-compose-shibb.yml
+++ b/docker-compose-shibb.yml
@@ -109,6 +109,7 @@ services:
       - ${HTTPS_PORT:-443}:443
     restart: unless-stopped
     volumes:
+      #- /etc/letsencrypt/archive/MISP:/etc/letsencrypt/archive/MISP:ro
       #- /etc/letsencrypt/live/MISP:/etc/letsencrypt/live/MISP:ro
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - ${HTTPS_PORT:-443}:443
     restart: unless-stopped
     volumes:
+      #- /etc/letsencrypt/archive/MISP:/etc/letsencrypt/archive/MISP:ro
       #- /etc/letsencrypt/live/MISP:/etc/letsencrypt/live/MISP:ro
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData

--- a/pages/configuration/general.md
+++ b/pages/configuration/general.md
@@ -86,7 +86,7 @@ your chosen CA's documentation for how to use other challenge types such as DNS-
     your alternate ACME-enabled CA's equivalent agreement).
 1. Installed Certbot on the host machine per the
     [Certbot documentation](https://certbot.eff.org/instructions).
-1. Uncomment the `/etc/letsencrypt/live/MISP` volume of `misp-web` in `docker-compose.yml`.
+1. Uncomment the two `/etc/letsencrypt/` volumes of `misp-web` in `docker-compose.yml`.
 1. Start MISP as usual and wait for until MISP is up and running.
 1. Use the following command to request the certificate, setting `--email`, `--webroot-path` and
     `--domain` to appropriate values for your environment and adding any additional options for your


### PR DESCRIPTION
# Description

Add volume for `/etc/letsencrypt/archive/MISP/` to allow symlinks to be followed during start up.

## Related Issue(s)

* Let's Encrypt certificate not loaded - reported by Shawn McKee at the University of Michigan.

## Type of change

Please tick options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

n/a - documentation change only.

**Test Configuration**:
* Docker Host OS: n/a
* Docker Engine Version: n/a
* MISP Version: n/a

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
