### PR TITLE
docs: Expected warnings

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -43,6 +43,8 @@ services:
     hostname: ${MODULES_HOSTNAME:-misp_modules}
     image: jisccti/misp-modules-dev:latest
     restart: unless-stopped
+    volumes:
+      - modules_cache:/mnt/cache/
   redis:
     entrypoint: redis-server --loglevel warning --requirepass ${REDIS_PASSWORD:-misp}
     environment:
@@ -115,3 +117,5 @@ services:
     volumes:
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG
+volumes:
+  modules_cache:

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -45,7 +45,7 @@ services:
     image: jisccti/misp-modules:latest
     restart: unless-stopped
     volumes:
-      - ./persistent/${COMPOSE_PROJECT_NAME}/modules_cache/:/mnt/cache
+      - modules_cache:/mnt/cache/
   redis:
     entrypoint: redis-server --loglevel warning --requirepass ${REDIS_PASSWORD:-misp}
     environment:
@@ -136,3 +136,5 @@ services:
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG
+volumes:
+  modules_cache:

--- a/docker-compose-shibb.yml
+++ b/docker-compose-shibb.yml
@@ -45,7 +45,7 @@ services:
     image: jisccti/misp-modules:latest
     restart: unless-stopped
     volumes:
-      - ./persistent/${COMPOSE_PROJECT_NAME}/modules_cache/:/mnt/cache
+      - modules_cache:/mnt/cache/
   redis:
     entrypoint: redis-server --loglevel warning --requirepass ${REDIS_PASSWORD:-misp}
     environment:
@@ -146,3 +146,5 @@ services:
       - ./persistent/${COMPOSE_PROJECT_NAME}/shibb/etc:/etc/shibboleth
       - ./persistent/${COMPOSE_PROJECT_NAME}/shibb/logs:/var/log/shibboleth
       - ./persistent/${COMPOSE_PROJECT_NAME}/shibb/run:/run/shibboleth
+volumes:
+  modules_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     image: jisccti/misp-modules:latest
     restart: unless-stopped
     volumes:
-      - ./persistent/${COMPOSE_PROJECT_NAME}/modules_cache/:/mnt/cache
+      - modules_cache:/mnt/cache/
   redis:
     entrypoint: redis-server --loglevel warning --requirepass ${REDIS_PASSWORD:-misp}
     environment:
@@ -128,3 +128,5 @@ services:
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG
+volumes:
+  modules_cache:

--- a/pages/deploy/local.md
+++ b/pages/deploy/local.md
@@ -30,6 +30,16 @@ By default the `docker-compose.yml` file provides ClamAV, MySQL and Redis. If yo
 these components another way, such as through managed Cloud Services, then please comment these
 sections out using `#`s at the start of each relevant line.
 
+## Enable Memory Overcommit for Redis
+
+To ensure proper operation of Redis, Memory Overcommit needs to be enabled on the host system.
+
+To do this:
+
+1. Open `/etc/sysctl.conf` for editing.
+2. Add `vm.overcommit_memory = 1` to the end of the file.
+3. Run `sudo sysctl -p`.
+
 ## Configure MISP
 
 Now move on to [Configuring MISP](../configuration/general.md).

--- a/pages/first_start.md
+++ b/pages/first_start.md
@@ -38,6 +38,9 @@ communication between workers and web is also required.
 For a [Cloud Deployment](deploy/cloud.md) follow your chosen provider's documentation to start the
 containers and monitor the logs for the above message.
 
+***NOTE*** The database container log will warn about the `--skip-host-cache` option being
+deprecated, this option is set within the container image itself and can be ignored.
+
 ## Access MISP
 
 Once MISP is running, and the Organisation Name and UUID have been set, go to


### PR DESCRIPTION
# Description

Update documentation to capture two expected warnings during start up.

Also map modules cache to a Docker-managed volume to ensure correct ownership and clear associated warning during start up.

## Related Issue(s)

* Feedback from HEAnet

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [ ] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.

**Test Configuration**:
* Docker Host OS: Ubuntu 22.04
* Docker Engine Version: 28.0.4
* MISP Version: 2.5.16

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
