### PR TITLE
Update libzip and other dependencies

### DIFF
--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -26,7 +26,7 @@ jobs:
             })
       - id: checkout
         name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - id: docker-login
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -15,7 +15,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         name: Add Comment to PR (Start)
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({
@@ -140,7 +140,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         name: Add Comment to PR (Done)
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install mkdocs

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build docs site
         run: mkdocs build
       - name: Upload site bundle
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site
   deploy:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup Python 3.11

--- a/.github/workflows/production-images.yml
+++ b/.github/workflows/production-images.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - id: docker-login
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/update-dockerhub.yml
+++ b/.github/workflows/update-dockerhub.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - id: modules
         name: MISP Modules
         uses: peter-evans/dockerhub-description@v4

--- a/misp-web/Dockerfile
+++ b/misp-web/Dockerfile
@@ -40,7 +40,7 @@ ARG MISP_VERSION=0.0.0 DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 # Install build dependencies
 RUN apt-get -qy update &&\
     apt-get -qy install --no-install-recommends cmake gcc git libcaca-dev libfuzzy-dev libgpgme11 libjpeg-dev liblua5.3-dev\
-    libopencv-dev libpoppler-cpp-dev librdkafka-dev libxml2-dev libxslt1-dev libyara-dev libzbar-dev libzip4 make\
+    libopencv-dev libpoppler-cpp-dev librdkafka-dev libxml2-dev libxslt1-dev libyara-dev libzbar-dev libzip5 make\
     openssl python3 python3-dev python3-venv ruby sqlite3 ssdeep tesseract-ocr unzip zip zlib1g-dev
 
 # Download MISP
@@ -129,7 +129,7 @@ ENV CAKE="sudo -H -u www-data /var/www/MISP/app/Console/cake"
 RUN apt-get -qy update &&\
     apt-get -qy upgrade apache2 &&\
     apt-get -qy install --no-install-recommends git gnupg iputils-ping libapache2-mod-shib\
-        libfuzzy2 libgd3 libgpgme11 libpng16-16 librdkafka1 libzip4 mariadb-client python3\
+        libfuzzy2 libgd3 libgpgme11 libpng16-16 librdkafka1 libzip5 mariadb-client python3\
         python3-venv ssdeep sudo uuid zip &&\
     rm -rf /var/lib/apt/lists/* &&\
     mkdir -p /opt/misp_custom &&\

--- a/misp-web/entrypoint.sh
+++ b/misp-web/entrypoint.sh
@@ -522,12 +522,12 @@ setup_db() {
         );
     }" >config/database.php
 
-    if mysql -h "$MYSQL_HOSTNAME" -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" <<<"SELECT id FROM users LIMIT 1" >/dev/null 2>&1; then
+    if mysql --skip-ssl-verify-server-cert -h "$MYSQL_HOSTNAME" -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" <<<"SELECT id FROM users LIMIT 1" >/dev/null 2>&1; then
         echo "Database schema appears to already be created"
     else
         echo "Database schema not present"
         echo "Creating database schema..."
-        mysql -h "$MYSQL_HOSTNAME" -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" </var/www/MISP/INSTALL/MYSQL.sql
+        mysql --skip-ssl-verify-server-cert -h "$MYSQL_HOSTNAME" -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" </var/www/MISP/INSTALL/MYSQL.sql
     fi
 }
 

--- a/misp-workers/Dockerfile
+++ b/misp-workers/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBIAN_FRONTEND=noninteractive DEBIAN_PRIORITY=critical
 RUN apt-get -qy update &&\
     apt-get -qy upgrade curl libtasn1-6 openssl libncurses6 libkrb5-3 gnutls-bin libxml2 systemd &&\
     apt-get -qy install git gnupg iputils-ping libfuzzy2 libgd3 libgpgme11 libpng16-16 librdkafka1\
-    libzip4 mariadb-client ssdeep sudo supervisor uuid zip && \
+    libzip5 mariadb-client ssdeep sudo supervisor uuid zip && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy in dependencies and MISP


### PR DESCRIPTION
# Description

Following updates to the base image, `libzip4` needs to be replaced with `libzip5`, additionally there are updates to several GitHub Actions actions.

Finally, the updated base image now defaults to attempting to validate TLS if offered by MySQL servers, this is incompatible with the dockerised MySQL Server so has been disabled.

## Related Issue(s)

* Production images not building

## Type of change

Please tick options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.

**Test Configuration**:
* Docker Host OS: Rocky Linux 9.6
* Docker Engine Version: 28.4.0
* MISP Version: 2.5.21

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
