### PR TITLE
Temp files cleanup

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023-2024 Jisc Services Limited
+# SPDX-FileCopyrightText: 2023-2026 Jisc Services Limited
 # SPDX-FileContributor: Joe Pitt
 #
 # SPDX-License-Identifier: GPL-3.0-only
@@ -76,6 +76,7 @@ services:
       - ${HTTPS_PORT:-443}:443
     restart: unless-stopped
     volumes:
+      - web_temp:/tmp
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG
       - ./persistent/${COMPOSE_PROJECT_NAME}/tls/:/etc/ssl/private
@@ -90,7 +91,9 @@ services:
     image: jisccti/misp-workers-dev:latest
     restart: unless-stopped
     volumes:
+      - web_temp:/tmp/misp-web
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG
 volumes:
   modules_cache:
+  web_temp:

--- a/docker-compose-ha.yml
+++ b/docker-compose-ha.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023-2025 Jisc Services Limited
+# SPDX-FileCopyrightText: 2023-2026 Jisc Services Limited
 # SPDX-FileContributor: Joe Pitt
 #
 # SPDX-License-Identifier: GPL-3.0-only
@@ -85,6 +85,7 @@ services:
     image: jisccti/misp-web:latest
     restart: unless-stopped
     volumes:
+      - web_temp:/tmp
       #- /etc/letsencrypt/archive/MISP:/etc/letsencrypt/archive/MISP:ro
       #- /etc/letsencrypt/live/MISP:/etc/letsencrypt/live/MISP:ro
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
@@ -102,8 +103,10 @@ services:
     image: jisccti/misp-workers:latest
     restart: unless-stopped
     volumes:
+      - web_temp:/tmp/misp-web
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG
 volumes:
   modules_cache:
+  web_temp:

--- a/docker-compose-shibb.yml
+++ b/docker-compose-shibb.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023-2025 Jisc Services Limited
+# SPDX-FileCopyrightText: 2023-2026 Jisc Services Limited
 # SPDX-FileContributor: Joe Pitt
 #
 # SPDX-License-Identifier: GPL-3.0-only
@@ -79,6 +79,7 @@ services:
       - ${HTTPS_PORT:-443}:443
     restart: unless-stopped
     volumes:
+      - web_temp:/tmp
       #- /etc/letsencrypt/archive/MISP:/etc/letsencrypt/archive/MISP:ro
       #- /etc/letsencrypt/live/MISP:/etc/letsencrypt/live/MISP:ro
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
@@ -98,6 +99,7 @@ services:
     image: jisccti/misp-workers:latest
     restart: unless-stopped
     volumes:
+      - web_temp:/tmp/misp-web
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG
@@ -117,3 +119,4 @@ services:
       - ./persistent/${COMPOSE_PROJECT_NAME}/shibb/run:/run/shibboleth
 volumes:
   modules_cache:
+  web_temp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023-2025 Jisc Services Limited
+# SPDX-FileCopyrightText: 2023-2026 Jisc Services Limited
 # SPDX-FileContributor: Joe Pitt
 #
 # SPDX-License-Identifier: GPL-3.0-only
@@ -77,6 +77,7 @@ services:
       - ${HTTPS_PORT:-443}:443
     restart: unless-stopped
     volumes:
+      - web_temp:/tmp
       #- /etc/letsencrypt/archive/MISP:/etc/letsencrypt/archive/MISP:ro
       #- /etc/letsencrypt/live/MISP:/etc/letsencrypt/live/MISP:ro
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
@@ -94,8 +95,10 @@ services:
     image: jisccti/misp-workers:latest
     restart: unless-stopped
     volumes:
+      - web_temp:/tmp/misp-web
       - ./persistent/${COMPOSE_PROJECT_NAME}/custom/:/opt/misp_custom
       - ./persistent/${COMPOSE_PROJECT_NAME}/data/:/var/www/MISPData
       - ./persistent/${COMPOSE_PROJECT_NAME}/gpg/:/var/www/MISPGnuPG
 volumes:
   modules_cache:
+  web_temp:

--- a/misp-web/scripts/misp_maintenance_jobs.ini
+++ b/misp-web/scripts/misp_maintenance_jobs.ini
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Jisc Services Limited
+# SPDX-FileCopyrightText: 2023-2026 Jisc Services Limited
 # SPDX-FileContributor: Joe Pitt
 #
 # SPDX-License-Identifier: GPL-3.0-only
@@ -8,6 +8,13 @@ authkey = 0000000000000000000000000000000000000000
 baseurl = hxxp://misp-web
 debug = False
 verifytls = False
+
+[cleanup_temp_files]
+command = /usr/bin/find /tmp/misp-web/ -type f -mmin +120 -delete
+enabled = True
+interval = 60
+lastrun = 0
+needsauthkey = False
 
 [rotate_logs]
 command = /var/www/MISP/venv/bin/python3 /opt/scripts/rotate_logs.py

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -10,7 +10,8 @@ This page tracks significant changes to the images.
 
 ## May 2026 - MISP >=2.5.37
 
-* Made MISP-Web `/tmp` directory a volume and added task to delete stale temporary files
+* Made MISP-Web `/tmp` directory a volume and added task to delete stale temporary files - requires
+    updating `docker-compose.yml` and `misp_maintenance_jobs.ini` to activate
 
 ## December 2025 - MISP >=2.5.27
 

--- a/pages/changelog.md
+++ b/pages/changelog.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 Jisc Services Limited
+SPDX-FileCopyrightText: 2025-2026 Jisc Services Limited
 SPDX-FileContributor: Joe Pitt
 
 SPDX-License-Identifier: GPL-3.0-only
@@ -7,6 +7,10 @@ SPDX-License-Identifier: GPL-3.0-only
 # Change Log
 
 This page tracks significant changes to the images.
+
+## May 2026 - MISP >=2.5.37
+
+* Made MISP-Web `/tmp` directory a volume and added task to delete stale temporary files
 
 ## December 2025 - MISP >=2.5.27
 

--- a/pages/dev/misp-web.md
+++ b/pages/dev/misp-web.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2025 Jisc Services Limited
+SPDX-FileCopyrightText: 2024-2026 Jisc Services Limited
 SPDX-FileContributor: Joe Pitt
 SPDX-FileContributor: James Ellor
 
@@ -89,5 +89,6 @@ The image uses the following volumes:
 | Mount Point | Purpose |
 |-------------|---------|
 | /etc/ssl/private/ | Holds the TLS certificate (and chain) (`misp.crt`) and the private key (`misp.key`) used to serve MISP over HTTPS. |
+| /tmp | Holds Apache and PHP temporary files. |
 | /var/www/MISPData | Holds the instance specific data which needs to be persisted between updates and container recreations. |
 | /var/www/MISPGnuPG | Holds the GPG/PGP key chain used by MISP for email signing and encryption. |

--- a/pages/dev/misp-workers.md
+++ b/pages/dev/misp-workers.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2025 Jisc Services Limited
+SPDX-FileCopyrightText: 2024-2026 Jisc Services Limited
 SPDX-FileContributor: Joe Pitt
 SPDX-FileContributor: James Ellor
 
@@ -44,5 +44,6 @@ The image uses the following volumes:
 
 | Mount Point | Purpose |
 |-------------|---------|
+| /tmp/misp-web | Holds Apache and PHP temporary files from misp-web. |
 | /var/www/MISPData | Holds the instance specific data which needs to be persisted between updates and container recreations. |
 | /var/www/MISPGnuPG | Holds the GPG/PGP key chain used by MISP for email signing and encryption. |


### PR DESCRIPTION
# Description

Add a job to clean up orphaned temporary files to prevent `/tmp` from growing exponentially.

`docker-compose.yml` and `misp_maintenance_jobs.ini` must be updated in existing deployments to activate this job.

## Related Issue(s)

* `/tmp` growing too large with temporary files not being cleaned up after RPZ generation

## Type of change

Please tick options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] GitHub Actions Development Images passing.
- [x] Manual deployment and testing of MISP successful.
- [x] Manually created temp files and ensure they are deleted.

**Test Configuration**:
* Docker Host OS: Ubuntu 24.04.4 LTS
* Docker Engine Version: 29.4.1
* MISP Version: 2.5.37

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
